### PR TITLE
feat: DateInput 컴포넌트 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,9 @@
   },
   "dependencies": {
     "@mui/material": "^5.11.3",
-    "@mui/styled-engine-sc": "^5.11.0",
     "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest",
+    "@mui/styled-engine-sc": "^5.11.0",
+    "dayjs": "^1.11.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.4.5",

--- a/src/components/DateInput.tsx
+++ b/src/components/DateInput.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef } from 'react';
+import { Dayjs } from 'dayjs';
+import { TextField } from '@mui/material';
+
+interface Props {
+  minDate: Dayjs;
+  maxDate?: Dayjs;
+  selectedDate: string;
+  onChange: (date: string) => void;
+  format?: string;
+}
+
+const DEFAULT_FORMAT = 'YYYY-MM-DD';
+
+export const DateInput: React.FC<Props> = (props: Props) => {
+  const { minDate, maxDate, onChange, selectedDate, format = DEFAULT_FORMAT } = props;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      const inputElement = inputRef.current;
+
+      inputElement.setAttribute('min', minDate.format(format));
+      maxDate && inputElement.setAttribute('max', maxDate.format(format));
+    }
+  }, [minDate, maxDate, format]);
+
+  return (
+    <TextField
+      inputRef={inputRef}
+      type="date"
+      hiddenLabel
+      size="small"
+      variant="outlined"
+      fullWidth
+      onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(event.target.value);
+      }}
+      value={selectedDate}
+    />
+  );
+};

--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -4,6 +4,8 @@ import { useRecoilState } from 'recoil';
 import { createMeetingState } from '../stores/createMeeting';
 import { TextField, InputLabel, Typography } from '@mui/material';
 import React from 'react';
+import { DateInput } from '../components/DateInput';
+import dayjs from 'dayjs';
 
 export function MeetingCreate() {
   const [meeting, setMeeting] = useRecoilState(createMeetingState);
@@ -12,6 +14,13 @@ export function MeetingCreate() {
     setMeeting({
       ...meeting,
       name: event.target.value,
+    });
+  };
+
+  const handleDeadlineChange = (deadline: string) => {
+    setMeeting({
+      ...meeting,
+      deadline,
     });
   };
 
@@ -40,6 +49,16 @@ export function MeetingCreate() {
               fullWidth
               placeholder="한사랑산악회 신년 모임"
               onChange={handleNameChange}
+            />
+          </div>
+          <div>
+            <InputLabel htmlFor="deadline" shrink>
+              투표 기한
+            </InputLabel>
+            <DateInput
+              selectedDate={meeting.deadline}
+              onChange={handleDeadlineChange}
+              minDate={dayjs()}
             />
           </div>
         </InputContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,6 +932,11 @@ csstype@^3.0.2, csstype@^3.1.1:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
   integrity sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==
 
+dayjs@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
+  integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
+
 debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
closes #18 

### 추가된 라이브러리

- dayjs
  - 날짜를 편하게 처리하기 위해 dayjs를 사용했습니다
  - 2kb 밖에 안되는 라이브러리이고 저희가 시간관련해서 딱히 대단한 기능을 사용하지 않을 것이라서 간단한것으로..

### 구현내용 ###

- 스타일을 맞추기 위해서 mui TextField 컴포넌트를 사용
- input type='date'로 작동하게 끔 구현
- mui에서 min, max가 없어서, inputRef를 이용해서 min, max를 처리

---

**스크린샷**

<img src="https://user-images.githubusercontent.com/49264892/212445367-6f385168-fb22-4374-bfc8-4bfdf4f36d81.png" />