### PR TITLE
feat: styled에서도 mui theme를 가져다 쓸 수 있게 수정

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, redirect, RouterProvider } from 'react-router-dom';
-import { createTheme, Theme, ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider as MuiThemeProivder, StyledEngineProvider } from '@mui/material/styles';
+import styled, { ThemeProvider as StyledThemeProvider } from 'styled-components';
 import { RecoilRoot } from 'recoil';
 import { MeetingCreate } from './pages/MeetingCreate';
 import { MeetingEdit } from './pages/MeetingEdit';
@@ -36,9 +37,11 @@ const router = createBrowserRouter([
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <RecoilRoot>
-      <ThemeProvider theme={theme}>
-        <RouterProvider router={router} />
-      </ThemeProvider>
+      <MuiThemeProivder theme={theme}>
+        <StyledThemeProvider theme={theme}>
+          <RouterProvider router={router} />
+        </StyledThemeProvider>
+      </MuiThemeProivder>
     </RecoilRoot>
   </React.StrictMode>,
 );

--- a/src/styled-component.d.ts
+++ b/src/styled-component.d.ts
@@ -1,0 +1,7 @@
+import 'styled-components';
+import { Theme } from '@mui/material/styles';
+
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends Theme {}
+}


### PR DESCRIPTION
## 주요 변경사항

- main.ts에 styled-component theme provider를 추가해줬습니다.
- styled-components.d.ts를 추가하고 여기에 mui theme를 extends할 수 있도록 했습니다.