### PR TITLE
Create Meeting 페이지 input validation 추가

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-VITE_API_BASE_URL=http://127.0.0.1:5001/to-be-determined-8620e/us-central1/
+VITE_API_BASE_URL=http://127.0.0.1:5001/to-be-determined-8620e/us-central1/v1/

--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -1,10 +1,10 @@
 import { AxiosResponse } from 'axios';
 
-import { CreateMeetingState } from '../stores/createMeeting';
+import { ValidCreateMeetingState } from '../stores/createMeeting';
 import { api } from './instance';
 import { CreateMeetingRequest, CreateMeetingResponse } from './types';
 
-const meetingStateToRequest = (state: Required<CreateMeetingState>): CreateMeetingRequest => {
+const meetingStateToRequest = (state: ValidCreateMeetingState): CreateMeetingRequest => {
   return {
     ...state,
     dates: state.dates.map((date) => date.toISOString()),
@@ -12,7 +12,7 @@ const meetingStateToRequest = (state: Required<CreateMeetingState>): CreateMeeti
   };
 };
 
-export const createMeeting = async (meeting: Required<CreateMeetingState>) => {
+export const createMeeting = async (meeting: ValidCreateMeetingState) => {  
   const meetingRequest = meetingStateToRequest(meeting);
 
   const response: AxiosResponse<CreateMeetingResponse> = await api.post(

--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -12,7 +12,7 @@ const meetingStateToRequest = (state: ValidCreateMeetingState): CreateMeetingReq
   };
 };
 
-export const createMeeting = async (meeting: ValidCreateMeetingState) => {  
+export const createMeeting = async (meeting: ValidCreateMeetingState) => {
   const meetingRequest = meetingStateToRequest(meeting);
 
   const response: AxiosResponse<CreateMeetingResponse> = await api.post(

--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -4,14 +4,15 @@ import { CreateMeetingState } from '../stores/createMeeting';
 import { api } from './instance';
 import { CreateMeetingRequest, CreateMeetingResponse } from './types';
 
-const meetingStateToRequest = (state: CreateMeetingState): CreateMeetingRequest => {
+const meetingStateToRequest = (state: Required<CreateMeetingState>): CreateMeetingRequest => {
   return {
     ...state,
     dates: state.dates.map((date) => date.toISOString()),
+    deadline: state.deadline.toISOString(),
   };
 };
 
-export const createMeeting = async (meeting: CreateMeetingState) => {
+export const createMeeting = async (meeting: Required<CreateMeetingState>) => {
   const meetingRequest = meetingStateToRequest(meeting);
 
   const response: AxiosResponse<CreateMeetingResponse> = await api.post(

--- a/src/components/DateInput.tsx
+++ b/src/components/DateInput.tsx
@@ -1,12 +1,12 @@
 import { TextField } from '@mui/material';
-import { Dayjs } from 'dayjs';
+import dayjs, { Dayjs } from 'dayjs';
 import React, { useEffect, useRef } from 'react';
 
 interface Props {
   minDate: Dayjs;
   maxDate?: Dayjs;
-  selectedDate: string;
-  onChange: (date: string) => void;
+  selectedDate?: Dayjs;
+  onChange: (date: Dayjs) => void;
   format?: string;
 }
 
@@ -15,6 +15,7 @@ const DEFAULT_FORMAT = 'YYYY-MM-DD';
 export const DateInput: React.FC<Props> = (props: Props) => {
   const { minDate, maxDate, onChange, selectedDate, format = DEFAULT_FORMAT } = props;
   const inputRef = useRef<HTMLInputElement>(null);
+  const inputValue = selectedDate ? selectedDate.format(format) : '';
 
   useEffect(() => {
     if (inputRef.current) {
@@ -34,9 +35,9 @@ export const DateInput: React.FC<Props> = (props: Props) => {
       variant="outlined"
       fullWidth
       onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
-        onChange(event.target.value);
+        onChange(dayjs(event.target.value));
       }}
-      value={selectedDate}
+      value={inputValue}
     />
   );
 };

--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -4,28 +4,47 @@ import { useRecoilState } from 'recoil';
 import { createMeeting } from '../apis/meetings';
 import { Page } from '../components/pageLayout';
 import useMeetingEdit from '../hooks/useMeetingEdit';
-import { CreateMeetingState, createMeetingState } from '../stores/createMeeting';
+import { createMeetingState, ValidCreateMeetingState } from '../stores/createMeeting';
+import { InputPasswordModal } from '../templates/MeetingEdit/InputPasswordModal';
 import { MeetingEditTemplate } from '../templates/MeetingEdit/MeetingEditTemplate';
 
+/**
+ * 모임생성 최상위 페이지
+ * - createMeetingState 상태 관리
+ * - 모임생성 API 호출
+ * - 모임의 수정과 겹치는 공통 로직은 MeetingEditTemplate에서 처리
+ */
 export function MeetingCreate() {
   const [meeting, setMeeting] = useRecoilState(createMeetingState);
+  const [showPasswordModal, setShowPasswordModal] = useState(false);
   const [currentStep, setCurrentStep] = useState<number>(0);
   const { getMeetingEditSteps } = useMeetingEdit();
   const meetingeditSteps = useMemo(() => {
     return getMeetingEditSteps('create');
   }, [getMeetingEditSteps]);
 
-  const onEndCreate = async () => {
-    if (meeting.name === undefined || meeting.deadline === undefined) {
-      return;
-    }
+  const handleMeetingEditComplete = () => {
+    setShowPasswordModal(true);
+  };
 
-    await createMeeting(meeting as Required<CreateMeetingState>);
+  const handlePasswordChange = (newPassword: string) => {
+    setMeeting((prev) => ({
+      ...prev,
+      password: newPassword,
+    }));
+  }
+
+  const handlePasswordConfirm = async (password?: string) => {
+    // 패스워드 입력 단계에서는 이미 유효성 검사를 마친 상태  
+    await createMeeting({
+      ...(meeting as ValidCreateMeetingState),
+      password,
+    });
     /**
      * @TODO
      * 응답 시 리다이렉팅
      */
-  };
+  }
 
   return (
     <Page>
@@ -35,8 +54,14 @@ export function MeetingCreate() {
         currentStep={currentStep}
         setStep={setCurrentStep}
         onChange={setMeeting}
-        onConfirm={onEndCreate}
+        onSubmit={handleMeetingEditComplete}
       ></MeetingEditTemplate>
+      <InputPasswordModal
+        show={showPasswordModal}
+        password={meeting.password}
+        onChange={handlePasswordChange}
+        onConfirm={handlePasswordConfirm}
+      />
     </Page>
   );
 }

--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -4,7 +4,7 @@ import { useRecoilState } from 'recoil';
 import { createMeeting } from '../apis/meetings';
 import { Page } from '../components/pageLayout';
 import useMeetingEdit from '../hooks/useMeetingEdit';
-import { createMeetingState } from '../stores/createMeeting';
+import { CreateMeetingState, createMeetingState } from '../stores/createMeeting';
 import { MeetingEditTemplate } from '../templates/MeetingEdit/MeetingEditTemplate';
 
 export function MeetingCreate() {
@@ -16,7 +16,11 @@ export function MeetingCreate() {
   }, [getMeetingEditSteps]);
 
   const onEndCreate = async () => {
-    await createMeeting(meeting);
+    if (meeting.name === undefined || meeting.deadline === undefined) {
+      return;
+    }
+
+    await createMeeting(meeting as Required<CreateMeetingState>);
     /**
      * @TODO
      * 응답 시 리다이렉팅

--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -32,10 +32,10 @@ export function MeetingCreate() {
       ...prev,
       password: newPassword,
     }));
-  }
+  };
 
   const handlePasswordConfirm = async (password?: string) => {
-    // 패스워드 입력 단계에서는 이미 유효성 검사를 마친 상태  
+    // 패스워드 입력 단계에서는 이미 유효성 검사를 마친 상태
     await createMeeting({
       ...(meeting as ValidCreateMeetingState),
       password,
@@ -44,7 +44,7 @@ export function MeetingCreate() {
      * @TODO
      * 응답 시 리다이렉팅
      */
-  }
+  };
 
   return (
     <Page>

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -14,6 +14,11 @@ export interface CreateMeetingState {
   password?: string;
 }
 
+export interface ValidCreateMeetingState extends CreateMeetingState{
+  name: string;
+  deadline: Dayjs;
+}
+
 export const initialState: CreateMeetingState = {
   name: undefined,
   dates: [],

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -71,3 +71,13 @@ export const validatePassword = (password: string) => {
   return isDigitString;
 }
 
+export const validateMeeting = (state: CreateMeetingState, today: Dayjs) => {
+  const { name, dates, deadline } = state;
+  const isNameValid = name !== undefined && validateMeetingName(name);
+  const isDatesValid = validateSelectedDates({ selectedDates: dates, today });
+  const isDeadlineValid = deadline !== undefined && validateDeadline({ deadline, today });
+
+  return isNameValid && isDatesValid && isDeadlineValid;
+
+}
+

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -14,7 +14,7 @@ export interface CreateMeetingState {
   password?: string;
 }
 
-export interface ValidCreateMeetingState extends CreateMeetingState{
+export interface ValidCreateMeetingState extends CreateMeetingState {
   name: string;
   deadline: Dayjs;
 }
@@ -35,7 +35,7 @@ export const createMeetingState = atom<CreateMeetingState>({
 
 export const validateMeetingName = (name: string) => {
   return name.length > 0;
-}
+};
 
 interface ValidateSelectedDatesProps {
   selectedDates: Dayjs[];
@@ -43,12 +43,14 @@ interface ValidateSelectedDatesProps {
 }
 
 export const validateSelectedDates = ({ selectedDates, today }: ValidateSelectedDatesProps) => {
-  if (selectedDates.length === 0){
+  if (selectedDates.length === 0) {
     return false;
   }
-  const isSameOrAfterToday = selectedDates.every((date) => date.isSame(today) || date.isAfter(today));
+  const isSameOrAfterToday = selectedDates.every(
+    (date) => date.isSame(today) || date.isAfter(today),
+  );
   return isSameOrAfterToday;
-}
+};
 
 interface ValidateDeadlineProps {
   deadline: Dayjs;
@@ -58,18 +60,18 @@ interface ValidateDeadlineProps {
 export const validateDeadline = ({ deadline, today }: ValidateDeadlineProps) => {
   const isSameOrAfterToday = deadline.isSame(today) || deadline.isAfter(today);
   return isSameOrAfterToday;
-}
+};
 
 export const validatePassword = (password: string) => {
   if (password.length !== 4) {
-    return false
+    return false;
   }
-  
+
   const digitStringRegex = /^[0-9]+$/;
   const isDigitString = digitStringRegex.test(password);
 
   return isDigitString;
-}
+};
 
 export const validateMeeting = (state: CreateMeetingState, today: Dayjs) => {
   const { name, dates, deadline } = state;
@@ -78,6 +80,4 @@ export const validateMeeting = (state: CreateMeetingState, today: Dayjs) => {
   const isDeadlineValid = deadline !== undefined && validateDeadline({ deadline, today });
 
   return isNameValid && isDatesValid && isDeadlineValid;
-
-}
-
+};

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -4,21 +4,21 @@ import { atom } from 'recoil';
 import { MeetingStatus, MeetingType } from '../constants/meeting';
 
 export interface CreateMeetingState {
-  name: string;
+  name?: string;
   /** 투표 가능 날짜, Dayjs */
   dates: Dayjs[];
   type: MeetingType;
   /** ISO date string with timezone */
-  deadline: string;
+  deadline?: Dayjs;
   status: MeetingStatus;
   password: string;
 }
 
 export const initialState: CreateMeetingState = {
-  name: '',
+  name: undefined,
   dates: [],
   type: MeetingType.date,
-  deadline: '',
+  deadline: undefined,
   status: MeetingStatus.inProgress,
   password: '',
 };
@@ -27,3 +27,42 @@ export const createMeetingState = atom<CreateMeetingState>({
   key: 'createMeeting',
   default: initialState,
 });
+
+export const validateMeetingName = (name: string) => {
+  return name.length > 0;
+}
+
+interface ValidateSelectedDatesProps {
+  selectedDates: Dayjs[];
+  today: Dayjs;
+}
+
+export const validateSelectedDates = ({ selectedDates, today }: ValidateSelectedDatesProps) => {
+  if (selectedDates.length === 0){
+    return false;
+  }
+  const isSameOrAfterToday = selectedDates.every((date) => date.isSame(today) || date.isAfter(today));
+  return isSameOrAfterToday;
+}
+
+interface ValidateDeadlineProps {
+  deadline: Dayjs;
+  today: Dayjs;
+}
+
+export const validateDeadline = ({ deadline, today }: ValidateDeadlineProps) => {
+  const isSameOrAfterToday = deadline.isSame(today) || deadline.isAfter(today);
+  return isSameOrAfterToday;
+}
+
+export const validatePassword = (password: string) => {
+  if (password.length !== 4) {
+    return false
+  }
+  
+  const digitStringRegex = /^[0-9]+$/;
+  const isDigitString = digitStringRegex.test(password);
+
+  return isDigitString;
+}
+

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -11,7 +11,7 @@ export interface CreateMeetingState {
   /** ISO date string with timezone */
   deadline?: Dayjs;
   status: MeetingStatus;
-  password: string;
+  password?: string;
 }
 
 export const initialState: CreateMeetingState = {
@@ -20,7 +20,7 @@ export const initialState: CreateMeetingState = {
   type: MeetingType.date,
   deadline: undefined,
   status: MeetingStatus.inProgress,
-  password: '',
+  password: undefined,
 };
 
 export const createMeetingState = atom<CreateMeetingState>({

--- a/src/templates/MeetingEdit/InputPasswordModal.tsx
+++ b/src/templates/MeetingEdit/InputPasswordModal.tsx
@@ -1,6 +1,7 @@
 import { Button, Modal, Typography } from '@mui/material';
 
 import { MaskingInput } from '../../components/MaskingInput';
+import { validatePassword } from '../../stores/createMeeting';
 import {
   FullHeightButtonGroup,
   MaskingInputContainer,
@@ -10,23 +11,31 @@ import {
 } from './styled';
 
 interface Props {
-  showMaskingInput: boolean;
-  password: string;
+  show: boolean;
+  password?: string;
   onChange: (newPassword: string) => void;
-  onConfirm: () => Promise<void>;
+  onConfirm: (password?: string) => Promise<void>;
 }
 
-export function InputPasswordModal({ showMaskingInput, password, onChange, onConfirm }: Props) {
-  const onEndCreate = () => {
+/**
+ * 비밀번호 생성 모달창
+ * - 비밀번호 유효성 검증과 표시
+ * - 버튼 클릭에 따라서 비밀번호를 인자로 onConfirm handler 호출
+ */
+export function InputPasswordModal({ show, password, onChange, onConfirm }: Props) {
+  const isPasswordValid = password !== undefined && validatePassword(password);
+  
+  const handleSkip = () => {
     onConfirm();
-    /**
-     * @TODO
-     * 응답 시 리다이렉팅
-     */
-  };
+  }
+
+  const handleSubmit = () => {
+    onConfirm(password);
+  }
+
   return (
     <>
-      <Modal open={showMaskingInput}>
+      <Modal open={show}>
         <PasswordContainer>
           <PasswordContent>
             <PasswordInput>
@@ -43,7 +52,7 @@ export function InputPasswordModal({ showMaskingInput, password, onChange, onCon
               <MaskingInputContainer>
                 <MaskingInput
                   length={4}
-                  text={password}
+                  text={password ?? ''}
                   setText={onChange}
                   size={28}
                   style={{ paddingTop: 10 }}
@@ -58,10 +67,10 @@ export function InputPasswordModal({ showMaskingInput, password, onChange, onCon
                 aria-label="Disabled elevation buttons"
               >
                 {/* ButtonGroup 컴포넌트의 borderRight 기본 스타일을 diable 하기 위하여 스타일 추가 */}
-                <Button color="transPrimary" onClick={onEndCreate} style={{ borderRight: 0 }}>
+                <Button color="transPrimary" onClick={handleSkip} style={{ borderRight: 0 }}>
                   생략하기
                 </Button>
-                <Button onClick={onEndCreate}>설정하기</Button>
+                <Button onClick={handleSubmit} disabled={!isPasswordValid}>설정하기</Button>
               </FullHeightButtonGroup>
             </div>
           </PasswordContent>

--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -7,7 +7,7 @@ import { DateInput } from '../../components/DateInput';
 import { Contents, Footer, Header, HeaderContainer } from '../../components/pageLayout';
 import { MeetingType } from '../../constants/meeting';
 import { IMeetingEditStep } from '../../hooks/useMeetingEdit';
-import { CreateMeetingState } from '../../stores/createMeeting';
+import { CreateMeetingState, validateMeetingName } from '../../stores/createMeeting';
 import { InputPasswordModal } from './InputPasswordModal';
 import { MeetingEditStepper } from './MeetingEditStepper';
 import { SelectDates } from './SelectDates';
@@ -112,6 +112,8 @@ const getMeetingEditContent = (
 ) => {
   switch (type) {
     case 'name':
+      const isMeetingInValid = meeting.name !== undefined && !validateMeetingName(meeting.name);
+      const helperText = isMeetingInValid ? '모임의 이름을 입력해주세요' : '';
       return (
         <TextField
           id="name"
@@ -120,6 +122,8 @@ const getMeetingEditContent = (
           variant="outlined"
           fullWidth
           placeholder="한사랑산악회 신년 모임"
+          error={isMeetingInValid}
+          helperText={helperText}
           onChange={(v) => {
             setValue((prev) => ({
               ...prev,

--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -1,6 +1,6 @@
 import { Button, TextField, Typography } from '@mui/material';
 import dayjs, { Dayjs } from 'dayjs';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { SetterOrUpdater } from 'recoil';
 
 import { DateInput } from '../../components/DateInput';
@@ -8,7 +8,6 @@ import { Contents, Footer, Header, HeaderContainer } from '../../components/page
 import { MeetingType } from '../../constants/meeting';
 import { IMeetingEditStep } from '../../hooks/useMeetingEdit';
 import { CreateMeetingState, validateDeadline, validateMeetingName, validateSelectedDates } from '../../stores/createMeeting';
-import { InputPasswordModal } from './InputPasswordModal';
 import { MeetingEditStepper } from './MeetingEditStepper';
 import { SelectDates } from './SelectDates';
 import { SelectMeetingType } from './SelectMeetingType';
@@ -19,17 +18,22 @@ export interface ICreateMeetingTemplateProps {
   meeting: CreateMeetingState;
   setStep?: SetterOrUpdater<number>;
   onChange: SetterOrUpdater<CreateMeetingState>;
-  onConfirm: () => Promise<void>;
+  onSubmit: () => void;
   meetingEditSteps: IMeetingEditStep[];
   pageType?: 'create' | 'modify';
 }
 
+/**
+ * 모임생성, 모임수정을 위한 공통 템플릿
+ * - Step 진행 애니메이션, Progress Bar, 메시지 처리
+ * - 모임생성, 모임수정에 공통적인 로직 처리
+ */
 export function MeetingEditTemplate({
   currentStep,
   meeting,
   setStep,
   onChange,
-  onConfirm,
+  onSubmit,
   meetingEditSteps,
   pageType,
 }: ICreateMeetingTemplateProps) {
@@ -53,7 +57,6 @@ export function MeetingEditTemplate({
     setStep?.((prev) => (prev > 0 ? prev - 1 : prev));
   };
 
-  const [showMaskingInput, setShowMaskingInput] = useState(false);
 
   return (
     <>
@@ -88,21 +91,10 @@ export function MeetingEditTemplate({
           {currentStep < meetingEditSteps.length - 1 ? (
             <Button onClick={onClickNext} disabled={!isCurrentStepValid}>다음</Button>
           ) : (
-            <Button onClick={() => setShowMaskingInput(true)}>생성하기</Button>
+            <Button onClick={onSubmit}>생성하기</Button>
           )}
         </FullHeightButtonGroup>
       </Footer>
-      <InputPasswordModal
-        showMaskingInput={showMaskingInput}
-        password={meeting.password}
-        onChange={(newPassword) => {
-          onChange((prev) => ({
-            ...prev,
-            password: newPassword,
-          }));
-        }}
-        onConfirm={onConfirm}
-      />
     </>
   );
 }

--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -7,7 +7,7 @@ import { DateInput } from '../../components/DateInput';
 import { Contents, Footer, Header, HeaderContainer } from '../../components/pageLayout';
 import { MeetingType } from '../../constants/meeting';
 import { IMeetingEditStep } from '../../hooks/useMeetingEdit';
-import { CreateMeetingState, validateDeadline, validateMeetingName, validateSelectedDates } from '../../stores/createMeeting';
+import { CreateMeetingState, validateDeadline, validateMeeting, validateMeetingName, validateSelectedDates } from '../../stores/createMeeting';
 import { MeetingEditStepper } from './MeetingEditStepper';
 import { SelectDates } from './SelectDates';
 import { SelectMeetingType } from './SelectMeetingType';
@@ -47,8 +47,11 @@ export function MeetingEditTemplate({
     return meetingEditSteps[currentStep]?.progress || 0;
   }, [currentStep]);
   const isCurrentStepValid = useMemo(() => {
-    return  getIsCurrentStepValid(meetingEditSteps[currentStep]?.type, meeting);
+    return getIsCurrentStepValid(meetingEditSteps[currentStep]?.type, meeting);
   }, [currentStep, meeting]);
+  const isMeetingValid = useMemo(() => {
+    return validateMeeting(meeting, dayjs().startOf('day'));
+  }, [meeting]);
 
   const onClickNext = () => {
     setStep?.((prev) => (prev < stepLen - 1 ? prev + 1 : prev));
@@ -91,7 +94,7 @@ export function MeetingEditTemplate({
           {currentStep < meetingEditSteps.length - 1 ? (
             <Button onClick={onClickNext} disabled={!isCurrentStepValid}>다음</Button>
           ) : (
-            <Button onClick={onSubmit}>생성하기</Button>
+            <Button onClick={onSubmit} disabled={!isMeetingValid} >생성하기</Button>
           )}
         </FullHeightButtonGroup>
       </Footer>

--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -177,7 +177,7 @@ const getMeetingEditContent = (
 };
 
 const getIsCurrentStepValid = (type: IMeetingEditStep['type'], meeting: CreateMeetingState) => {
-  const today = dayjs();
+  const today = dayjs().startOf('day');
   
   switch (type) {
     case 'name':


### PR DESCRIPTION
closes #59 

## Summary

- meetingName에 대한 input 컴포넌트 자체의 validation 추가
  - 다른 컴포넌트는 validation이 불필요하거나 컴포넌트 자체에 이미 내장되어 있음
- 각 step 별로 validation 결과에 따라서 '다음'버튼 활성화
- 미입력 상태는 undefined 값으로 구분하여 잘못입력된 빈 값과 구분함

## Discussions

- 지금은 현재 Step이 검증되면 `다음` 버튼이 활성화되도록 처리했으나, 지나간 Step도 수정이 가능하기 때문에 로직 상 지금까지의 Step이 모두 검증되어야 `다음` 버튼을 활성화시켜야 할 것 같습니다. 
- Step별로 input의 검증상태를 유지하고, 이를 Step 단계에 따라서 종합하여 disable 여부를 판단해야 하는데 어떻게 로직을 넣어야 할지 좋은 아이디어 있으시면 코멘트 부탁드립니다. 