### PR TITLE
투표 테이블 추가

### DIFF
--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -1,4 +1,5 @@
 import React, { CSSProperties, PropsWithChildren } from 'react';
+
 import { ChipContainer } from './styled';
 
 interface Props {
@@ -6,7 +7,7 @@ interface Props {
   style?: CSSProperties;
   checked?: boolean;
   focus?: boolean;
-  onClick?: () => void;
+  onClick?: (checked: boolean) => void;
 }
 
 export function Chip(props: PropsWithChildren<Props>) {
@@ -14,7 +15,13 @@ export function Chip(props: PropsWithChildren<Props>) {
 
   return (
     <div className={className} style={style}>
-      <ChipContainer onClick={onClick} checked={checked} focus={focus}>
+      <ChipContainer
+        onClick={() => {
+          onClick?.(!checked);
+        }}
+        checked={checked}
+        focus={focus}
+      >
         {children}
       </ChipContainer>
     </div>

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,0 +1,42 @@
+import React, { CSSProperties } from 'react';
+
+import { Chip } from '../Chip/Chip';
+import { UserListContainer } from './styled';
+
+export type DataType = {
+  checked: boolean;
+  focused: boolean;
+};
+
+export type UserDataType = DataType & {
+  username: string;
+};
+
+export type handler<T extends DataType> = (checked: boolean, target: T) => void;
+
+type Props = {
+  style?: CSSProperties;
+  users: UserDataType[];
+  handleClick?: handler<UserDataType>;
+};
+
+export const UserList: React.FC<Props> = (props) => {
+  const { users, style, handleClick } = props;
+
+  return (
+    <UserListContainer style={style}>
+      {users.map((targetUser, index) => (
+        <Chip
+          key={index}
+          checked={targetUser.checked}
+          focus={targetUser.focused}
+          onClick={(checked) => {
+            handleClick?.(checked, targetUser);
+          }}
+        >
+          {targetUser.username}
+        </Chip>
+      ))}
+    </UserListContainer>
+  );
+};

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -12,12 +12,10 @@ export interface UserListData extends VoteData {
   username: string;
 }
 
-export type handler<T extends VoteData> = (checked: boolean, target: T) => void;
-
 interface Props {
   style?: CSSProperties;
   users: UserListData[];
-  onClick?: handler<UserListData>;
+  onClick?: (checked: boolean, target: UserListData) => void;
 }
 
 export const UserList: React.FC<Props> = (props) => {

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -13,16 +13,17 @@ export interface UserListData extends VoteData {
 }
 
 interface Props {
+  className?: string;
   style?: CSSProperties;
   users: UserListData[];
   onClick?: (checked: boolean, target: UserListData) => void;
 }
 
 export const UserList: React.FC<Props> = (props) => {
-  const { users, style, onClick } = props;
+  const { users, style, className, onClick } = props;
 
   return (
-    <UserListContainer style={style}>
+    <UserListContainer className={className} style={style}>
       {users.map((targetUser, index) => (
         <Chip
           key={index}

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -3,25 +3,25 @@ import React, { CSSProperties } from 'react';
 import { Chip } from '../Chip/Chip';
 import { UserListContainer } from './styled';
 
-export type DataType = {
+export interface VoteData {
   checked: boolean;
   focused: boolean;
-};
+}
 
-export type UserDataType = DataType & {
+export interface UserListData extends VoteData {
   username: string;
-};
+}
 
-export type handler<T extends DataType> = (checked: boolean, target: T) => void;
+export type handler<T extends VoteData> = (checked: boolean, target: T) => void;
 
-type Props = {
+interface Props {
   style?: CSSProperties;
-  users: UserDataType[];
-  handleClick?: handler<UserDataType>;
-};
+  users: UserListData[];
+  onClick?: handler<UserListData>;
+}
 
 export const UserList: React.FC<Props> = (props) => {
-  const { users, style, handleClick } = props;
+  const { users, style, onClick } = props;
 
   return (
     <UserListContainer style={style}>
@@ -30,8 +30,8 @@ export const UserList: React.FC<Props> = (props) => {
           key={index}
           checked={targetUser.checked}
           focus={targetUser.focused}
-          onClick={(checked) => {
-            handleClick?.(checked, targetUser);
+          onClick={(checked: boolean) => {
+            onClick?.(checked, targetUser);
           }}
         >
           {targetUser.username}

--- a/src/components/UserList/styled.ts
+++ b/src/components/UserList/styled.ts
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export const UserListContainer = styled.div`
+  display: flex;
+  gap: 8px;
+`;

--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -1,0 +1,76 @@
+import dayjs from 'dayjs';
+
+import { handler, VoteData } from '../UserList/UserList';
+import {
+  ContentBox,
+  ContentWrapper,
+  DateContentBox,
+  Divider,
+  Header,
+  HeaderBox,
+  VoteTableContainer,
+  Wrapper,
+} from './styled';
+
+interface Voting extends VoteData {
+  total: number;
+  current: number;
+}
+
+export interface VoteTableData {
+  date: dayjs.Dayjs;
+  votings: Voting[];
+}
+
+interface Props {
+  data: VoteTableData[];
+  onClick?: handler<Voting>;
+}
+
+export const VoteTable: React.FC<Props> = (props) => {
+  const { data, onClick } = props;
+
+  return (
+    <VoteTableContainer>
+      <Header>
+        <HeaderBox>투표 가능 날짜</HeaderBox>
+        <Divider />
+        <HeaderBox>점심</HeaderBox>
+        <HeaderBox>저녁</HeaderBox>
+      </Header>
+      <ContentWrapper>
+        {data.map((item, idx) => (
+          <VoteTableContent onClick={onClick} key={`vote-item-${idx}`} item={item} />
+        ))}
+      </ContentWrapper>
+    </VoteTableContainer>
+  );
+};
+
+interface VoteTableContentProps {
+  item: VoteTableData;
+  onClick?: handler<Voting>;
+}
+
+const VoteTableContent: React.FC<VoteTableContentProps> = (props) => {
+  const { item, onClick } = props;
+  const { date, votings } = item;
+
+  return (
+    <Wrapper>
+      <DateContentBox>{date.format('M/D (dd)')}</DateContentBox>
+      <Divider />
+      {votings.map((vote, idx) => {
+        const { current, total, focused, checked } = vote;
+        return (
+          <ContentBox
+            key={`vote-content-${idx}`}
+            focus={focused}
+            checked={checked}
+            onClick={() => onClick?.(!checked, vote)}
+          >{`${current}/${total} (${(current / total) * 100}%)`}</ContentBox>
+        );
+      })}
+    </Wrapper>
+  );
+};

--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -1,4 +1,5 @@
-import dayjs from 'dayjs';
+import { Dayjs } from 'dayjs';
+import { CSSProperties } from 'react';
 
 import { VoteData } from '../UserList/UserList';
 import {
@@ -18,22 +19,24 @@ interface Voting extends VoteData {
 }
 
 export interface VoteTableData {
-  date: dayjs.Dayjs;
+  date: Dayjs;
   votings: Voting[];
 }
 
 type onClickHandler = (checked: boolean, target: Voting) => void;
 
 interface Props {
+  className?: string;
+  style?: CSSProperties;
   data: VoteTableData[];
   onClick?: onClickHandler;
 }
 
 export const VoteTable: React.FC<Props> = (props) => {
-  const { data, onClick } = props;
+  const { data, onClick, style, className } = props;
 
   return (
-    <VoteTableContainer>
+    <VoteTableContainer className={className} style={style}>
       <Header>
         <HeaderBox>투표 가능 날짜</HeaderBox>
         <Divider />

--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -1,5 +1,5 @@
 import { Dayjs } from 'dayjs';
-import { CSSProperties } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 
 import { VoteData } from '../UserList/UserList';
 import {
@@ -20,7 +20,7 @@ interface Voting extends VoteData {
 
 export interface VoteTableData {
   date: Dayjs;
-  votings: Voting[];
+  votings: [Voting, Voting] | [Voting];
 }
 
 type onClickHandler = (checked: boolean, target: Voting) => void;
@@ -30,18 +30,21 @@ interface Props {
   style?: CSSProperties;
   data: VoteTableData[];
   onClick?: onClickHandler;
+
+  headers: ReactNode[];
 }
 
 export const VoteTable: React.FC<Props> = (props) => {
-  const { data, onClick, style, className } = props;
+  const { data, onClick, style, className, headers } = props;
 
   return (
     <VoteTableContainer className={className} style={style}>
       <Header>
         <HeaderBox>투표 가능 날짜</HeaderBox>
         <Divider />
-        <HeaderBox>점심</HeaderBox>
-        <HeaderBox>저녁</HeaderBox>
+        {headers.map((header, idx) => (
+          <HeaderBox key={`vote-table-header-${idx}`}>{header}</HeaderBox>
+        ))}
       </Header>
       <ContentWrapper>
         {data.map((item, idx) => (

--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-import { handler, VoteData } from '../UserList/UserList';
+import { VoteData } from '../UserList/UserList';
 import {
   ContentBox,
   ContentWrapper,
@@ -22,9 +22,11 @@ export interface VoteTableData {
   votings: Voting[];
 }
 
+type onClickHandler = (checked: boolean, target: Voting) => void;
+
 interface Props {
   data: VoteTableData[];
-  onClick?: handler<Voting>;
+  onClick?: onClickHandler;
 }
 
 export const VoteTable: React.FC<Props> = (props) => {
@@ -49,7 +51,7 @@ export const VoteTable: React.FC<Props> = (props) => {
 
 interface VoteTableContentProps {
   item: VoteTableData;
-  onClick?: handler<Voting>;
+  onClick?: onClickHandler;
 }
 
 const VoteTableContent: React.FC<VoteTableContentProps> = (props) => {

--- a/src/components/VoteTable/styled.tsx
+++ b/src/components/VoteTable/styled.tsx
@@ -1,0 +1,74 @@
+import styled, { css } from 'styled-components';
+
+export const VoteTableContainer = styled.div``;
+
+export const Header = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+export const ContentWrapper = styled.div``;
+
+const commonStyle = css`
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 105px;
+  height: 30px;
+  font-size: 12px;
+  margin-bottom: 8px;
+`;
+
+export const HeaderBox = styled.div`
+  ${commonStyle}
+  font-weight: 700;
+  background-color: ${({ theme }) => theme.palette.secondary.main};
+`;
+
+export const DateContentBox = styled.div`
+  ${commonStyle}
+  background-color: white;
+  border: 1px solid ${({ theme }) => theme.palette.secondary.main};
+`;
+
+export const ContentBox = styled.button<{ checked?: boolean; focus?: boolean }>`
+  ${commonStyle}
+  background-color: white;
+  border: 1px solid ${({ theme }) => theme.palette.secondary.main};
+  cursor: pointer;
+  box-shadow: ${({ focus }) => (focus ? `inset 0 0 0 2px #009568` : `none`)};
+
+  ${(props) => {
+    const {
+      checked,
+      theme: {
+        palette: { primary },
+      },
+    } = props;
+
+    if (checked) {
+      return css`
+        background-color: ${primary.main};
+        border: 1px solid ${primary.main};
+        color: white;
+      `;
+    }
+  }};
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  gap: 8px;
+
+  &:last-child {
+    button,
+    div {
+      margin-bottom: 0;
+    }
+  }
+`;
+
+export const Divider = styled.div`
+  border: 1px solid ${({ theme }) => theme.palette.secondary.main};
+`;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,8 @@
 import '../index.css';
+import 'dayjs/locale/ko';
 
 import { ThemeProvider } from '@mui/material/styles';
+import dayjs from 'dayjs';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { createBrowserRouter, redirect, RouterProvider } from 'react-router-dom';
@@ -12,6 +14,8 @@ import { MeetingModify } from './pages/MeetingModify';
 import { MeetingResult } from './pages/MeetingResult';
 import { MeetingView } from './pages/MeetingView';
 import { theme } from './theme';
+
+dayjs.locale('ko');
 
 const router = createBrowserRouter([
   {

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -1,3 +1,40 @@
+import dayjs from 'dayjs';
+
+import { VoteTable, VoteTableData } from '../components/VoteTable/VoteTable';
+
 export function MeetingView() {
-  return <div>MeetingView Page</div>;
+  const mockData: VoteTableData[] = [
+    {
+      date: dayjs('2022-11-26T01:44:39.114Z'),
+      votings: [
+        { total: 8, current: 8, checked: false, focused: false },
+        { total: 8, current: 3, checked: true, focused: false },
+      ],
+    },
+    {
+      date: dayjs('2022-11-26T01:44:39.114Z'),
+      votings: [
+        { total: 8, current: 5, checked: true, focused: false },
+        { total: 8, current: 3, checked: false, focused: false },
+      ],
+    },
+  ];
+
+  const mockData2: VoteTableData[] = [
+    {
+      date: dayjs('2022-11-26T01:44:39.114Z'),
+      votings: [{ total: 8, current: 8, checked: false, focused: false }],
+    },
+    {
+      date: dayjs('2022-11-26T01:44:39.114Z'),
+      votings: [{ total: 8, current: 5, checked: true, focused: false }],
+    },
+  ];
+
+  return (
+    <div>
+      <VoteTable data={mockData} headers={['점심', '저녁']} />
+      <VoteTable data={mockData2} headers={['투표 현황']} />
+    </div>
+  );
 }


### PR DESCRIPTION
close #52 

## 주요 변경 사항

- 유저 리스트처럼 데이터의 focus, checked에 따라서 표시가 달라지게 구현했습니다.
- 데이터 구조를 임의로 짜서 해서 나중에 구조를 바꿔야할수도있습니다.

## 고민

- 컴포넌트만 만들면 저희 firebase에서 배포해주는거에서 볼 수가 없어서 mockdata를 추가해봤는데 이렇게하는거 어떠세요?
   -  /meeting/view 로 가시면 mock으로 확인하실 수 있습니다.

