### PR TITLE
username 입력 모달 추가

### DIFF
--- a/src/components/CenterContentModal.tsx
+++ b/src/components/CenterContentModal.tsx
@@ -1,0 +1,43 @@
+import { Modal } from '@mui/material';
+import { PropsWithChildren } from 'react';
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export const Content = styled.div<{ width: number; height: number }>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  background-color: white;
+  width: ${({ width }) => `${width}px`};
+  height: ${({ height }) => `${height}px`};
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+interface Props {
+  open: boolean;
+  width: number;
+  height: number;
+}
+
+export function CenterContentModal(props: PropsWithChildren<Props>) {
+  const { open, width, height, children } = props;
+
+  return (
+    <Modal open={open}>
+      <Container>
+        <Content width={width} height={height}>
+          {children}
+        </Content>
+      </Container>
+    </Modal>
+  );
+}

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -69,7 +69,14 @@ export function MeetingView() {
       </Contents>
       <Footer>
         {isViewMode ? (
-          <div>다시 투표하러 가기</div>
+          <FullHeightButtonGroup
+            fullWidth
+            disableElevation
+            variant="contained"
+            aria-label="Disabled elevation buttons"
+          >
+            <Button onClick={() => setIsViewMode(false)}>다시 투표하러 가기</Button>
+          </FullHeightButtonGroup>
         ) : (
           <FullHeightButtonGroup
             fullWidth
@@ -77,25 +84,10 @@ export function MeetingView() {
             variant="contained"
             aria-label="Disabled elevation buttons"
           >
-            <Button
-              color="secondary"
-              onClick={() => {
-                /**
-                 * @TODO viewmode로 변경
-                 */
-              }}
-            >
+            <Button color="secondary" onClick={() => setIsViewMode(true)}>
               다음에하기
             </Button>
-            <Button
-              onClick={() => {
-                /**
-                 * @TODO 투표 api
-                 */
-              }}
-            >
-              투표하기
-            </Button>
+            <Button onClick={() => setShowUsernameModal(true)}>투표하기</Button>
           </FullHeightButtonGroup>
         )}
       </Footer>

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -12,6 +12,7 @@ import { VoteTable } from '../components/VoteTable/VoteTable';
 import { useMeetingViewVoteMode } from '../hooks/useMeetingViewVoteMode';
 import { currentUserState } from '../stores/currentUser';
 import { userListState, userMapState } from '../stores/voting';
+import { InputUsernameModal } from '../templates/MeetingView/InputUsernameModal';
 
 export function MeetingView() {
   const currentUser = useRecoilValue(currentUserState);
@@ -25,6 +26,15 @@ export function MeetingView() {
   const userList = useRecoilValue(userListState);
 
   const { voteTableDataList, handleClickVoteTableSlot } = useMeetingViewVoteMode(meeting);
+
+  const [showUsernameModal, setShowUsernameModal] = useState<boolean>(false);
+
+  const handlePasswordConfirm = (username: string) => {
+    /**
+     * @TODO
+     * 투표 반영 API
+     */
+  };
 
   useEffect(() => {
     (async () => {
@@ -89,6 +99,12 @@ export function MeetingView() {
           </FullHeightButtonGroup>
         )}
       </Footer>
+      <InputUsernameModal
+        show={showUsernameModal}
+        usernameList={userList.map((user) => user.username)}
+        onConfirm={handlePasswordConfirm}
+        onCancel={() => setShowUsernameModal(false)}
+      ></InputUsernameModal>
     </Page>
   );
 }

--- a/src/templates/MeetingEdit/InputPasswordModal.tsx
+++ b/src/templates/MeetingEdit/InputPasswordModal.tsx
@@ -1,15 +1,10 @@
-import { Button, Modal, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 
+import { CenterContentModal } from '../../components/CenterContentModal';
 import { MaskingInput } from '../../components/MaskingInput';
 import { FullHeightButtonGroup } from '../../components/styled';
 import { validatePassword } from '../../stores/createMeeting';
-import {
-  MaskingInputContainer,
-  PasswordContainer,
-  PasswordContent,
-  PasswordInput,
-  PasswordSkipBtn,
-} from './styled';
+import { MaskingInputContainer, PasswordInput, PasswordSkipBtn } from './styled';
 
 interface Props {
   show: boolean;
@@ -36,58 +31,52 @@ export function InputPasswordModal({ show, password, onChange, onConfirm, onCanc
   };
 
   return (
-    <>
-      <Modal open={show}>
-        <PasswordContainer>
-          <PasswordContent>
-            <PasswordInput>
-              <Typography variant="subtitle1" fontWeight={300}>
-                비밀번호를 설정할 수 있어요.
-              </Typography>
-              <Typography
-                variant="subtitle2"
-                fontWeight={300}
-                style={{ paddingTop: 10, paddingBottom: 10 }}
-              >
-                모임을 수정하거나 확정할 때 사용해요
-              </Typography>
-              <MaskingInputContainer>
-                <MaskingInput
-                  length={4}
-                  text={password ?? ''}
-                  setText={onChange}
-                  size={28}
-                  style={{ paddingTop: 10 }}
-                />
-              </MaskingInputContainer>
-            </PasswordInput>
-            <div style={{ height: 50 }}>
-              <FullHeightButtonGroup
-                fullWidth
-                disableElevation
-                variant="contained"
-                aria-label="Disabled elevation buttons"
-              >
-                <Button color="secondary" onClick={onCancel}>
-                  취소하기
-                </Button>
-                <Button onClick={handleSubmit} disabled={!isPasswordValid}>
-                  설정하기
-                </Button>
-              </FullHeightButtonGroup>
-            </div>
-            <PasswordSkipBtn
-              color="primary"
-              variant="text"
-              size="small"
-              onClick={handleSkip}
-              style={{ borderRight: 0 }}
-            >
-              생략하기
-            </PasswordSkipBtn>
-          </PasswordContent>
-        </PasswordContainer>
-      </Modal>
-    </>
+    <CenterContentModal open={show} width={330} height={230}>
+      <PasswordInput>
+        <Typography variant="subtitle1" fontWeight={300}>
+          비밀번호를 설정할 수 있어요.
+        </Typography>
+        <Typography
+          variant="subtitle2"
+          fontWeight={300}
+          style={{ paddingTop: 10, paddingBottom: 10 }}
+        >
+          모임을 수정하거나 확정할 때 사용해요
+        </Typography>
+        <MaskingInputContainer>
+          <MaskingInput
+            length={4}
+            text={password ?? ''}
+            setText={onChange}
+            size={28}
+            style={{ paddingTop: 10 }}
+          />
+        </MaskingInputContainer>
+      </PasswordInput>
+      <div style={{ height: 50 }}>
+        <FullHeightButtonGroup
+          fullWidth
+          disableElevation
+          variant="contained"
+          aria-label="Disabled elevation buttons"
+        >
+          <Button color="secondary" onClick={onCancel}>
+            취소하기
+          </Button>
+          <Button onClick={handleSubmit} disabled={!isPasswordValid}>
+            설정하기
+          </Button>
+        </FullHeightButtonGroup>
+      </div>
+      <PasswordSkipBtn
+        color="primary"
+        variant="text"
+        size="small"
+        onClick={handleSkip}
+        style={{ borderRight: 0 }}
+      >
+        생략하기
+      </PasswordSkipBtn>
+    </CenterContentModal>
   );
 }

--- a/src/templates/MeetingEdit/styled.tsx
+++ b/src/templates/MeetingEdit/styled.tsx
@@ -56,26 +56,6 @@ export const StepBoxContainer = styled.div`
   flex-direction: column;
 `;
 
-export const PasswordContainer = styled.div`
-  width: 100%;
-  height: 100%;
-`;
-
-export const PasswordContent = styled.div`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-
-  background-color: white;
-  width: 330px;
-  height: 230px;
-
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-`;
-
 export const PasswordInput = styled.div`
   padding: 25px 35px;
 

--- a/src/templates/MeetingView/InputUsernameModal.tsx
+++ b/src/templates/MeetingView/InputUsernameModal.tsx
@@ -1,0 +1,70 @@
+import { Button, InputLabel, TextField } from '@mui/material';
+import { useState } from 'react';
+
+import { CenterContentModal } from '../../components/CenterContentModal';
+import { FullHeightButtonGroup } from '../../components/styled';
+
+enum InvalidText {
+  EMPTY = '참석자 이름을 입력해주세요',
+  DUP = '중복된 이름입니다',
+}
+
+interface Props {
+  show: boolean;
+  usernameList: string[];
+  onConfirm: (username: string) => void;
+  onCancel: () => void;
+}
+
+export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: Props) {
+  const [username, setUsername] = useState('');
+  const [invalidText, setInvalidText] = useState<InvalidText | ''>('');
+
+  const onChangeTextField = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setUsername(value);
+
+    if (value.length === 0) {
+      setInvalidText(InvalidText.EMPTY);
+    } else if (!validation(value)) {
+      setInvalidText(InvalidText.DUP);
+    } else {
+      setInvalidText('');
+    }
+  };
+
+  /** username이 usernameList에 있지 않아 valid한 경우 true */
+  const validation = (username: string): boolean => !usernameList.includes(username);
+
+  return (
+    <>
+      <CenterContentModal open={show} width={330} height={170}>
+        <div style={{ position: 'relative', height: '100%' }}>
+          <div style={{ padding: 25 }}>
+            <InputLabel shrink>참석자 이름</InputLabel>
+            <TextField
+              id="userId"
+              size="small"
+              variant="outlined"
+              fullWidth
+              value={username}
+              onChange={onChangeTextField}
+              error={invalidText !== ''}
+              helperText={invalidText}
+            />
+          </div>
+          <FullHeightButtonGroup
+            fullWidth
+            variant="contained"
+            style={{ height: 45, position: 'absolute', bottom: 0 }}
+          >
+            <Button color="secondary" onClick={onCancel}>
+              다음에
+            </Button>
+            <Button onClick={() => onConfirm(username)}>완료</Button>
+          </FullHeightButtonGroup>
+        </div>
+      </CenterContentModal>
+    </>
+  );
+}


### PR DESCRIPTION
- InputPasswordModal 리팩토링
  mui Modal의 중앙에 컴포넌트를 적용할 수 있도록 스타일 요소를 `CenterContentModal` 컴포넌트로 분리

- username 입력 모달 추가

- viewmode 변경, 투표 완료 버튼 시 username 입력 모달 보이는 기능 추가
  기본이 view 모드이고 투표모드로 변경하여 모달을 테스트해볼 수 있도록 기능 추가