### PR TITLE
MeetingView 페이지에서 MeetingVote 페이지를 별도로 분리

### DIFF
--- a/src/apis/users.ts
+++ b/src/apis/users.ts
@@ -41,7 +41,7 @@ const usersResponseToState = (response: GetUsersResponse): UserMap => {
   return responseCopy;
 };
 
-export const getUsers = async (meetingId: number) => {
+export const getUsers = async (meetingId: string) => {
   const response: AxiosResponse<GetUsersResponse> = await api.get(`/meetings/${meetingId}/users`);
 
   const userMap = usersResponseToState(response.data);

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -11,6 +11,7 @@ import { MeetingCreate } from './pages/MeetingCreate';
 import { MeetingModify } from './pages/MeetingModify';
 import { MeetingResult } from './pages/MeetingResult';
 import { MeetingView } from './pages/MeetingView';
+import { MeetingVote } from './pages/MeetingVote';
 import { showProgressState } from './stores/showProgress';
 import { theme } from './theme';
 
@@ -28,6 +29,10 @@ const router = createBrowserRouter([
   {
     path: 'meetings/:meetingId',
     element: <MeetingView />,
+  },
+  {
+    path: 'meetings/:meetingId/vote',
+    element: <MeetingVote />,
   },
   {
     path: 'meetings/:meetingId/modify',

--- a/src/hooks/useMeetingViewVoteMode.ts
+++ b/src/hooks/useMeetingViewVoteMode.ts
@@ -11,7 +11,6 @@ import { getVotingCountByDay, userVotingsState } from '../stores/voting';
 export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
   // userMap, currentUserVotings, lastClickedSlot, lastClickedUser 상태관리
   const [currentUserVotingSlots, setCurrentUserVotingSlots] = useState<VotingSlot[]>([]);
-  const [lastClickedSlot, setLastClickedSlot] = useState<VotingSlot>();
 
   const userVotingsValue = useRecoilValue(userVotingsState);
   const currentUserVotings: UserVotings = {
@@ -29,7 +28,7 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
         current: getVotingCountByDay(day, userVotingsWithCurrentUser),
         total: userVotingsValue.length,
         checked: currentUserVotingSlots.some((voting) => voting.date.isSame(day, 'day')),
-        focused: lastClickedSlot?.date.isSame(day, 'day') ?? false,
+        focused: false,
       },
     ],
   }));
@@ -46,7 +45,6 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
     } else {
       setCurrentUserVotingSlots((prev) => [...prev, slot]);
     }
-    setLastClickedSlot(slot);
   };
 
   return {

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -31,7 +31,7 @@ export function MeetingView() {
 
   useEffect(() => {
     (async () => {
-      const data = await getUsers(1);
+      const data = await getUsers(MEETING_ID);
       setUserMap(data);
 
       const meetingData = await getMeeting(MEETING_ID);

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -15,16 +15,10 @@ import { userListState, userMapState } from '../stores/voting';
 
 export function MeetingVote() {
   const currentUser = useRecoilValue(currentUserState);
-  const [isViewMode, setIsViewMode] = useState<boolean>(!!currentUser);
 
   const MEETING_ID = '1';
-
-  const [userMap, setUserMap] = useRecoilState<UserMap>(userMapState);
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
-
-  // const { handleClickUserList, handleClickVoteTable, userList, voteTableDataList } =
-  //   useMeetingView(meeting);
-
+  const [userMap, setUserMap] = useRecoilState<UserMap>(userMapState);
   const userList = useRecoilValue(userListState);
 
   const { voteTableDataList, handleClickVoteTableSlot } = useMeetingViewVoteMode(meeting);
@@ -37,7 +31,7 @@ export function MeetingVote() {
       const meetingData = await getMeeting(MEETING_ID);
       setMeeting(meetingData);
     })();
-  }, [setUserMap, isViewMode]);
+  }, [setUserMap]);
 
   if (!meeting || !voteTableDataList) {
     return null;
@@ -52,7 +46,6 @@ export function MeetingVote() {
       </Header>
       <Contents>
         <div>toast message</div>
-
         <UserList users={userList} />
         {/* <VoteTable data={mockData} headers={['점심', '저녁']} /> */}
         <VoteTable
@@ -62,36 +55,32 @@ export function MeetingVote() {
         />
       </Contents>
       <Footer>
-        {isViewMode ? (
-          <div>다시 투표하러 가기</div>
-        ) : (
-          <FullHeightButtonGroup
-            fullWidth
-            disableElevation
-            variant="contained"
-            aria-label="Disabled elevation buttons"
+        <FullHeightButtonGroup
+          fullWidth
+          disableElevation
+          variant="contained"
+          aria-label="Disabled elevation buttons"
+        >
+          <Button
+            color="secondary"
+            onClick={() => {
+              /**
+               * @TODO viewmode로 변경
+               */
+            }}
           >
-            <Button
-              color="secondary"
-              onClick={() => {
-                /**
-                 * @TODO viewmode로 변경
-                 */
-              }}
-            >
-              다음에하기
-            </Button>
-            <Button
-              onClick={() => {
-                /**
-                 * @TODO 투표 api
-                 */
-              }}
-            >
-              투표하기
-            </Button>
-          </FullHeightButtonGroup>
-        )}
+            다음에하기
+          </Button>
+          <Button
+            onClick={() => {
+              /**
+               * @TODO 투표 api
+               */
+            }}
+          >
+            투표하기
+          </Button>
+        </FullHeightButtonGroup>
       </Footer>
     </Page>
   );

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -1,5 +1,6 @@
 import { Alert, Button } from '@mui/material';
 import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
@@ -13,11 +14,16 @@ import { useMeetingViewVoteMode } from '../hooks/useMeetingViewVoteMode';
 import { currentUserState } from '../stores/currentUser';
 import { userListState, userMapState } from '../stores/voting';
 
+interface MeetingVoteRouteParams {
+  meetingId: string;
+}
+
 export function MeetingVote() {
+  const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
+
   const currentUser = useRecoilValue(currentUserState);
   const isNewUser = !currentUser;
 
-  const MEETING_ID = '1';
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
   const [userMap, setUserMap] = useRecoilState<UserMap>(userMapState);
   const userList = useRecoilValue(userListState);
@@ -26,13 +32,13 @@ export function MeetingVote() {
 
   useEffect(() => {
     (async () => {
-      const data = await getUsers(1);
+      const data = await getUsers(meetingId);
       setUserMap(data);
 
-      const meetingData = await getMeeting(MEETING_ID);
+      const meetingData = await getMeeting(meetingId);
       setMeeting(meetingData);
     })();
-  }, [setUserMap]);
+  }, [meetingId, setUserMap]);
 
   if (!meeting || !voteTableDataList) {
     return null;

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@mui/material';
+import { Alert, Button } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
@@ -15,6 +15,7 @@ import { userListState, userMapState } from '../stores/voting';
 
 export function MeetingVote() {
   const currentUser = useRecoilValue(currentUserState);
+  const isNewUser = !currentUser;
 
   const MEETING_ID = '1';
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
@@ -41,11 +42,13 @@ export function MeetingVote() {
     <Page>
       <Header>
         <HeaderContainer>
-          <h1>모임 이름</h1>
+          <h1>{meeting.name}</h1>
         </HeaderContainer>
       </Header>
       <Contents>
-        <div>toast message</div>
+        {isNewUser && (
+          <Alert severity="warning">이미 투표한 적이 있으면 아이디를 눌러주세요.</Alert>
+        )}
         <UserList users={userList} />
         {/* <VoteTable data={mockData} headers={['점심', '저녁']} /> */}
         <VoteTable

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -28,6 +28,8 @@ export function MeetingVote() {
   const [userMap, setUserMap] = useRecoilState<UserMap>(userMapState);
   const userList = useRecoilValue(userListState);
 
+  const navigate = useNavigate();
+
   const { voteTableDataList, handleClickVoteTableSlot } = useMeetingViewVoteMode(meeting);
 
   useEffect(() => {
@@ -73,9 +75,7 @@ export function MeetingVote() {
           <Button
             color="secondary"
             onClick={() => {
-              /**
-               * @TODO viewmode로 변경
-               */
+              navigate(`/meetings/${meetingId}`);
             }}
           >
             다음에하기

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -1,0 +1,98 @@
+import { Button } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+
+import { getMeeting } from '../apis/meetings';
+import { GetMeetingResponse } from '../apis/types';
+import { getUsers, UserMap } from '../apis/users';
+import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
+import { FullHeightButtonGroup } from '../components/styled';
+import { UserList } from '../components/UserList/UserList';
+import { VoteTable } from '../components/VoteTable/VoteTable';
+import { useMeetingViewVoteMode } from '../hooks/useMeetingViewVoteMode';
+import { currentUserState } from '../stores/currentUser';
+import { userListState, userMapState } from '../stores/voting';
+
+export function MeetingVote() {
+  const currentUser = useRecoilValue(currentUserState);
+  const [isViewMode, setIsViewMode] = useState<boolean>(!!currentUser);
+
+  const MEETING_ID = '1';
+
+  const [userMap, setUserMap] = useRecoilState<UserMap>(userMapState);
+  const [meeting, setMeeting] = useState<GetMeetingResponse>();
+
+  // const { handleClickUserList, handleClickVoteTable, userList, voteTableDataList } =
+  //   useMeetingView(meeting);
+
+  const userList = useRecoilValue(userListState);
+
+  const { voteTableDataList, handleClickVoteTableSlot } = useMeetingViewVoteMode(meeting);
+
+  useEffect(() => {
+    (async () => {
+      const data = await getUsers(1);
+      setUserMap(data);
+
+      const meetingData = await getMeeting(MEETING_ID);
+      setMeeting(meetingData);
+    })();
+  }, [setUserMap, isViewMode]);
+
+  if (!meeting || !voteTableDataList) {
+    return null;
+  }
+
+  return (
+    <Page>
+      <Header>
+        <HeaderContainer>
+          <h1>모임 이름</h1>
+        </HeaderContainer>
+      </Header>
+      <Contents>
+        <div>toast message</div>
+
+        <UserList users={userList} />
+        {/* <VoteTable data={mockData} headers={['점심', '저녁']} /> */}
+        <VoteTable
+          onClick={handleClickVoteTableSlot}
+          data={voteTableDataList}
+          headers={['투표 현황']}
+        />
+      </Contents>
+      <Footer>
+        {isViewMode ? (
+          <div>다시 투표하러 가기</div>
+        ) : (
+          <FullHeightButtonGroup
+            fullWidth
+            disableElevation
+            variant="contained"
+            aria-label="Disabled elevation buttons"
+          >
+            <Button
+              color="secondary"
+              onClick={() => {
+                /**
+                 * @TODO viewmode로 변경
+                 */
+              }}
+            >
+              다음에하기
+            </Button>
+            <Button
+              onClick={() => {
+                /**
+                 * @TODO 투표 api
+                 */
+              }}
+            >
+              투표하기
+            </Button>
+          </FullHeightButtonGroup>
+        )}
+      </Footer>
+    </Page>
+  );
+}


### PR DESCRIPTION
closes #75 

## Summary

- MeetingVote 페이지 분리 및 불필요한 변수, hook 제거
- 신규 route path 추가 및 MeetingVote 페이지 등록
- 선택된 유저가 없을 경우 toast 노출
- meetingId 값을 path param으로 사용
- 보기모드로 전환 기능
- 날짜 focus 기능 제거