### PR TITLE
Vote 페이지에서 신규유저 <-> 기존유저 전환 기능 추가

### DIFF
--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react';
 
+import { User } from '../../stores/currentUser';
 import { Chip } from '../Chip/Chip';
 import { UserListContainer } from './styled';
 
@@ -10,9 +11,7 @@ export interface UserListVoteData {
   focused: boolean;
 }
 
-export interface UserListData extends UserListVoteData {
-  username: string;
-}
+export interface UserListData extends UserListVoteData, User {}
 
 interface Props {
   className?: string;

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -9,8 +9,9 @@ import { MeetingType } from '../constants/meeting';
 import { getVotingCountByDay, votingsState } from '../stores/voting';
 
 export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
-  // userMap, currentUserVotings, lastClickedSlot, lastClickedUser 상태관리
-  const [currentUserVotingSlots, setCurrentUserVotingSlots] = useState<VotingSlot[]>([]);
+  const [currentUserVotingSlots, setCurrentUserVotingSlots] = useRecoilState(
+    currentUserVotingSlotsState,
+  );
 
   const votings = useRecoilValue(votingsState);
   // TODO: 신규 유저 외에 기존 유저 선택 시 로직 반영

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -1,14 +1,16 @@
 import dayjs, { Dayjs } from 'dayjs';
-import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { GetMeetingResponse } from '../apis/types';
 import { Voting, VotingSlot } from '../apis/votes';
 import { VoteTableRowData, VoteTableVoting } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
+import { currentUserState } from '../stores/currentUser';
+import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { getVotingCountByDay, votingsState } from '../stores/voting';
 
 export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
+  const currentUser = useRecoilValue(currentUserState);
   const [currentUserVotingSlots, setCurrentUserVotingSlots] = useRecoilState(
     currentUserVotingSlotsState,
   );
@@ -16,8 +18,8 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
   const votings = useRecoilValue(votingsState);
   // TODO: 신규 유저 외에 기존 유저 선택 시 로직 반영
   const currentVoting: Voting = {
-    id: 'newUser',
-    username: 'newUser',
+    id: currentUser?.id ?? 'newUser',
+    username: currentUser?.username ?? 'newUser',
     dateType: meeting?.type === MeetingType.date ? currentUserVotingSlots : [],
     mealType: meeting?.type === MeetingType.meal ? currentUserVotingSlots : [],
   };
@@ -54,6 +56,7 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
   return {
     voteTableDataList,
     currentUserVotingSlots,
+    setCurrentUserVotingSlots,
     handleClickVoteTableSlot,
   };
 };

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -45,23 +45,25 @@ export function MeetingVote() {
     })();
   }, [meetingId, setVotings]);
 
-  const handleClickUser = (checked: boolean, userListData: UserListData) => {
+  const handleClickUser = (checked: boolean, clickedUser: UserListData) => {
     if (!meeting) {
       return;
     }
 
-    setCurrentUser({
-      id: userListData.id,
-      username: userListData.username,
-    });
-
-    const previousVoting = votings.find((voting) => voting.username === userListData.username);
-    if (!previousVoting) {
+    const isCurrentUserClicked = currentUser?.id === clickedUser.id;
+    if (isCurrentUserClicked) {
+      setCurrentUser(undefined);
       setCurrentUserVotingSlots([]);
       return;
     }
 
-    const previousVotingSlots = previousVoting[meeting.type];
+    setCurrentUser({
+      id: clickedUser.id,
+      username: clickedUser.username,
+    });
+
+    const previousVoting = votings.find((voting) => voting.username === clickedUser.username);
+    const previousVotingSlots = previousVoting?.[meeting.type];
     setCurrentUserVotingSlots(previousVotingSlots ?? []);
   };
 

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -12,6 +12,7 @@ import { UserList, UserListData } from '../components/UserList/UserList';
 import { VoteTable } from '../components/VoteTable/VoteTable';
 import { useMeetingViewVoteMode } from '../hooks/useMeetingVote';
 import { currentUserState } from '../stores/currentUser';
+import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { userListState, votingsState } from '../stores/voting';
 
 interface MeetingVoteRouteParams {
@@ -22,10 +23,11 @@ export function MeetingVote() {
   const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
 
   const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
+  const setCurrentUserVotingSlots = useSetRecoilState(currentUserVotingSlotsState);
   const isNewUser = !currentUser;
 
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
-  const setVotings = useSetRecoilState(votingsState);
+  const [votings, setVotings] = useRecoilState(votingsState);
   const userList = useRecoilValue(userListState);
 
   const navigate = useNavigate();
@@ -44,10 +46,23 @@ export function MeetingVote() {
   }, [meetingId, setVotings]);
 
   const handleClickUser = (checked: boolean, userListData: UserListData) => {
+    if (!meeting) {
+      return;
+    }
+
     setCurrentUser({
       id: userListData.id,
       username: userListData.username,
     });
+
+    const previousVoting = votings.find((voting) => voting.username === userListData.username);
+    if (!previousVoting) {
+      setCurrentUserVotingSlots([]);
+      return;
+    }
+
+    const previousVotingSlots = previousVoting[meeting.type];
+    setCurrentUserVotingSlots(previousVotingSlots ?? []);
   };
 
   if (!meeting || !voteTableDataList) {

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -1,14 +1,14 @@
 import { Alert, Button } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
 import { GetMeetingResponse } from '../apis/types';
 import { createVoting, getVotings } from '../apis/votes';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
 import { FullHeightButtonGroup } from '../components/styled';
-import { UserList } from '../components/UserList/UserList';
+import { UserList, UserListData } from '../components/UserList/UserList';
 import { VoteTable } from '../components/VoteTable/VoteTable';
 import { useMeetingViewVoteMode } from '../hooks/useMeetingVote';
 import { currentUserState } from '../stores/currentUser';
@@ -21,7 +21,7 @@ interface MeetingVoteRouteParams {
 export function MeetingVote() {
   const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
 
-  const currentUser = useRecoilValue(currentUserState);
+  const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
   const isNewUser = !currentUser;
 
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
@@ -43,6 +43,13 @@ export function MeetingVote() {
     })();
   }, [meetingId, setVotings]);
 
+  const handleClickUser = (checked: boolean, userListData: UserListData) => {
+    setCurrentUser({
+      id: userListData.id,
+      username: userListData.username,
+    });
+  };
+
   if (!meeting || !voteTableDataList) {
     return null;
   }
@@ -58,8 +65,11 @@ export function MeetingVote() {
         {isNewUser && (
           <Alert severity="warning">이미 투표한 적이 있으면 아이디를 눌러주세요.</Alert>
         )}
+        {!isNewUser && (
+          <Alert severity="warning">{`${currentUser.username}님의 투표를 수정합니다`}</Alert>
+        )}
         {/* TODO: 유저 목록에서 기존유저 클릭 시 로직 반영 */}
-        <UserList users={userList} />
+        <UserList users={userList} onClick={handleClickUser} />
         {/* <VoteTable data={mockData} headers={['점심', '저녁']} /> */}
         <VoteTable
           onClick={handleClickVoteTableSlot}

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
 import { GetMeetingResponse } from '../apis/types';
@@ -23,6 +23,7 @@ export function MeetingVote() {
   const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
 
   const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
+  const resetCurrentUser = useResetRecoilState(currentUserState);
   const setCurrentUserVotingSlots = useSetRecoilState(currentUserVotingSlotsState);
   const isNewUser = !currentUser;
 
@@ -53,6 +54,7 @@ export function MeetingVote() {
     const isCurrentUserClicked = currentUser?.id === clickedUser.id;
     if (isCurrentUserClicked) {
       setCurrentUser(undefined);
+      resetCurrentUser();
       setCurrentUserVotingSlots([]);
       return;
     }

--- a/src/stores/currentUser.ts
+++ b/src/stores/currentUser.ts
@@ -2,14 +2,13 @@ import { atom } from 'recoil';
 
 import { localstorageEffect } from './localstorageEffect';
 
-type IUser =
-  | {
-      id: number;
-      name: string;
-    }
-  | undefined;
+export interface User {
+  id: string;
+  username: string;
+}
+
 export const currentUserState = atom({
-  key: 'currentUserID',
+  key: 'currentUser',
   default: undefined,
-  effects: [localstorageEffect<IUser>('current_user')],
+  effects: [localstorageEffect<User | undefined>('current_user')],
 });

--- a/src/stores/currentUserVotingSlots.ts
+++ b/src/stores/currentUserVotingSlots.ts
@@ -1,0 +1,8 @@
+import { atom } from 'recoil';
+
+import { VotingSlot } from '../apis/votes';
+
+export const currentUserVotingSlotsState = atom<VotingSlot[]>({
+  key: 'currentUserVotingSlots',
+  default: [],
+});

--- a/src/stores/voting.ts
+++ b/src/stores/voting.ts
@@ -71,6 +71,7 @@ export const userListState = selector({
 
     return votings.map<UserListData>((user) => {
       return {
+        id: user.id,
         username: user.username,
         checked: false,
         focused: false,


### PR DESCRIPTION
closes #76 

## Summary

- MeetingVote 페이지에서 UserList 클릭을 통해서 신규유저 <-> 기존유저 전환기능
  - 기존유저가 선택된 상태에서 유저 선택 시 토글되어 신규 유저로 전환
  - 기존유저로 전환 시 DB에 저장된 투표상태로 currentUserVotingSlots 초기화
  - 신규유저로 전환 시 currentUserVotingSlots를 빈 배열로 전환