### PR TITLE
feat: 투표 상태를 투명도로 표시

### DIFF
--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -10,6 +10,7 @@ import {
   Divider,
   Header,
   HeaderBox,
+  OpacityProgress,
   VoteTableContainer,
   Wrapper,
 } from './styled';
@@ -42,6 +43,8 @@ interface Props {
 export const VoteTable: React.FC<Props> = (props) => {
   const { data, onClick, style, className, headers } = props;
 
+  const isHideVotingStatus = data.some((item) => item.votings.some((vote) => vote.checked));
+
   return (
     <VoteTableContainer className={className} style={style}>
       <Header>
@@ -53,7 +56,12 @@ export const VoteTable: React.FC<Props> = (props) => {
       </Header>
       <ContentWrapper>
         {data.map((item, idx) => (
-          <VoteTableContent onClick={onClick} key={`vote-item-${idx}`} item={item} />
+          <VoteTableContent
+            isHideVotingStatus={isHideVotingStatus}
+            onClick={onClick}
+            key={`vote-item-${idx}`}
+            item={item}
+          />
         ))}
       </ContentWrapper>
     </VoteTableContainer>
@@ -63,10 +71,11 @@ export const VoteTable: React.FC<Props> = (props) => {
 interface VoteTableContentProps {
   item: VoteTableRowData;
   onClick?: onClickHandler;
+  isHideVotingStatus: boolean;
 }
 
 const VoteTableContent: React.FC<VoteTableContentProps> = (props) => {
-  const { item, onClick } = props;
+  const { item, onClick, isHideVotingStatus } = props;
   const { date, votings } = item;
 
   return (
@@ -75,13 +84,20 @@ const VoteTableContent: React.FC<VoteTableContentProps> = (props) => {
       <Divider />
       {votings.map((vote, idx) => {
         const { current, total, focused, checked } = vote;
+        const progress = Number(((current / total || 0) * 100).toFixed(0));
+
         return (
           <ContentBox
+            progress={progress}
+            isHideVotingStatus={isHideVotingStatus}
             key={`vote-content-${idx}`}
             focus={focused}
             checked={checked}
             onClick={() => onClick?.(date, !checked, vote, { date })}
-          >{`${current}/${total} (${((current / total || 0) * 100).toFixed(0)}%)`}</ContentBox>
+          >
+            <OpacityProgress isHide={isHideVotingStatus} progress={progress} />
+            <span>{`${current}/${total} (${progress}%)`}</span>
+          </ContentBox>
         );
       })}
     </Wrapper>

--- a/src/components/VoteTable/styled.tsx
+++ b/src/components/VoteTable/styled.tsx
@@ -32,12 +32,24 @@ export const DateContentBox = styled.div`
   border: 1px solid ${({ theme }) => theme.palette.secondary.main};
 `;
 
-export const ContentBox = styled.button<{ checked?: boolean; focus?: boolean }>`
+export const ContentBox = styled.button<{
+  checked?: boolean;
+  focus?: boolean;
+  progress: number;
+  isHideVotingStatus: boolean;
+}>`
+  position: relative;
+  color: ${({ progress, isHideVotingStatus }) =>
+    progress >= 80 && !isHideVotingStatus ? 'white' : 'black'};
   ${commonStyle}
   background-color: white;
   border: 1px solid ${({ theme }) => theme.palette.secondary.main};
   cursor: pointer;
   box-shadow: ${({ focus }) => (focus ? `inset 0 0 0 2px #009568` : `none`)};
+
+  > span {
+    z-index: 10;
+  }
 
   ${(props) => {
     const {
@@ -71,4 +83,16 @@ export const Wrapper = styled.div`
 
 export const Divider = styled.div`
   border: 1px solid ${({ theme }) => theme.palette.secondary.main};
+`;
+
+export const OpacityProgress = styled.div<{ progress: number; isHide: boolean }>`
+  display: ${({ isHide }) => (isHide ? 'none' : 'block')};
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  background-color: ${({ theme }) => theme.palette.primary.main};
+  opacity: ${({ progress }) => `${progress}%`};
+  width: 100%;
+  height: 100%;
 `;


### PR DESCRIPTION
## 변경사항

- 투표 상태를 투명도로 표시했습니다.
- 투명도가 80퍼센트 이상인 경우 글자를 흰색으로 바꿉니다.

## 스크린샷
<img width="300" alt="스크린샷 2023-06-10 오전 11 49 09" src="https://github.com/Team-Panopticon/TBD-client/assets/49264892/e29e0330-f359-41cb-ac20-4b0545e62389">
<img width="300" alt="스크린샷 2023-06-10 오전 11 49 05" src="https://github.com/Team-Panopticon/TBD-client/assets/49264892/53686829-2d42-4dc7-99cc-2bd351dc002d">

close #94 
