### PR TITLE
MeetingConfirm 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest",
     "@mui/styled-engine-sc": "^5.11.0",
     "@mui/x-date-pickers": "^5.0.14",
+    "@tanstack/react-query": "^4.29.19",
     "axios": "^1.3.2",
     "dayjs": "^1.11.7",
     "immer": "^10.0.1",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { useSetRecoilState } from 'recoil';
 
 import { initializeProgressInterceptor } from './apis/instance';
 import { Progress } from './components/Progress';
+import { ProtectedAdminRoute } from './components/ProtectedAdminRoute';
 import { GlobalStyle } from './GlobalStyle';
 import { MeetingConfirm } from './pages/MeetingConfirm';
 import { MeetingCreate } from './pages/MeetingCreate';
@@ -37,7 +38,11 @@ const router = createBrowserRouter([
   },
   {
     path: 'meetings/:meetingId/vote',
-    element: <MeetingVote />,
+    element: (
+      <ProtectedAdminRoute>
+        <MeetingVote />
+      </ProtectedAdminRoute>
+    ),
   },
   {
     path: 'meetings/:meetingId/modify',
@@ -49,7 +54,11 @@ const router = createBrowserRouter([
   },
   {
     path: 'meetings/:meetingId/confirm',
-    element: <MeetingConfirm />,
+    element: (
+      <ProtectedAdminRoute>
+        <MeetingConfirm />
+      </ProtectedAdminRoute>
+    ),
   },
 ]);
 

--- a/src/components/ProtectedAdminRoute.tsx
+++ b/src/components/ProtectedAdminRoute.tsx
@@ -1,0 +1,26 @@
+import { Navigate, useParams } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
+
+import { adminTokenState } from '../stores/adminToken';
+
+interface ProtectedAdminRouteProps {
+  children: JSX.Element;
+}
+
+export function ProtectedAdminRoute({ children }: ProtectedAdminRouteProps) {
+  const { meetingId } = useParams<'meetingId'>();
+  const adminToken = useRecoilValue(adminTokenState);
+  const isLoggedInAsAdmin = adminToken !== undefined;
+
+  if (!meetingId) {
+    console.log('navigate to new meetings');
+    return <Navigate to="/meetings/new" replace />;
+  }
+
+  if (!isLoggedInAsAdmin) {
+    console.log('navigate to meetings view');
+    return <Navigate to={`/meetings/${meetingId}`} replace />;
+  }
+
+  return children;
+}

--- a/src/components/pageLayout.tsx
+++ b/src/components/pageLayout.tsx
@@ -31,6 +31,10 @@ export const HeaderContainer = styled('div')({
     fontSize: '24px',
     fontWeight: '700',
   },
+
+  h2: {
+    marginTop: '4px',
+  },
 });
 
 const ContentsWrapper = styled('div')`

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import '../index.css';
 import 'dayjs/locale/ko';
 
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { RecoilRoot } from 'recoil';
@@ -12,10 +13,14 @@ if (process.env.NODE_ENV === 'development' && import.meta.env.VITE_USE_MSW) {
   worker.start();
 }
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <RecoilRoot>
-      <App />
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
     </RecoilRoot>
   </React.StrictMode>,
 );

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -136,6 +136,7 @@ export function MeetingConfirm() {
       </Footer>
       <CheckConfirmModal
         show={showConfirmModal}
+        slot={selectedSlot}
         onConfirm={handleConfirm}
         onCancel={() => {
           setShowConfirmModal(false);

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -1,3 +1,70 @@
+import { Button } from '@mui/material';
+import { useQuery } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+
+import { getMeeting } from '../apis/meetings';
+import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
+import { FullHeightButtonGroup } from '../components/styled';
+
+interface MeetingConfirmPathParams {
+  meetingId: string;
+}
+
 export function MeetingConfirm() {
-  return <div>MeetingConfirm</div>;
+  const { meetingId } = useParams<keyof MeetingConfirmPathParams>() as MeetingConfirmPathParams;
+  const {
+    data: meeting,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['meeting', meetingId],
+    queryFn: () => getMeeting(meetingId),
+  });
+
+  if (isLoading || isError) {
+    return null;
+  }
+
+  return (
+    <Page>
+      <Header>
+        <HeaderContainer>
+          <h1>{meeting.name}</h1>
+        </HeaderContainer>
+      </Header>
+      <Contents>
+        {/* <UserList users={userList} onClick={handleClickUserList} />
+        <VoteTable
+          onClick={handleClickVoteTable}
+          data={voteTableDataList}
+          headers={meeting.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
+        /> */}
+      </Contents>
+      <Footer>
+        <FullHeightButtonGroup
+          fullWidth
+          disableElevation
+          variant="contained"
+          aria-label="Disabled elevation buttons"
+        >
+          <Button
+            color="secondary"
+            onClick={() => {
+              console.log('취소하기');
+            }}
+          >
+            취소하기
+          </Button>
+          <Button
+            color="primary"
+            onClick={() => {
+              console.log('모임시간 확정');
+            }}
+          >
+            모임시간 확정
+          </Button>
+        </FullHeightButtonGroup>
+      </Footer>
+    </Page>
+  );
 }

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
-import { getMeeting } from '../apis/meetings';
+import { confirmMeeting, getMeeting } from '../apis/meetings';
 import { getVotings, Voting, VotingSlot } from '../apis/votes';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
 import { FullHeightButtonGroup } from '../components/styled';
@@ -74,9 +74,20 @@ export function MeetingConfirm() {
     handleVoteTableClickHightlight(date, checked, target, slot);
   };
 
-  const handleConfirm = () => {
-    // TODO: 모임시간 확정 API 호출
-    navigate(`/meetings/${meetingId}/result`);
+  const handleConfirm = async () => {
+    if (!selectedSlot) {
+      return;
+    }
+
+    try {
+      await confirmMeeting(meetingId, selectedSlot);
+      navigate(`/meetings/${meetingId}/result`);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : '정상적으로 처리되지 못했습니다.';
+      alert(errorMessage);
+      setShowConfirmModal(false);
+    }
   };
 
   return (

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -1,10 +1,20 @@
 import { Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
+import { Dayjs } from 'dayjs';
+import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
+import { useSetRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
+import { getVotings, Voting, VotingSlot } from '../apis/votes';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
 import { FullHeightButtonGroup } from '../components/styled';
+import { UserList } from '../components/UserList/UserList';
+import { VoteTable, VoteTableVoting } from '../components/VoteTable/VoteTable';
+import { MeetingType } from '../constants/meeting';
+import { useMeetingView } from '../hooks/useMeetingView';
+import { isSameSlot } from '../hooks/useMeetingVote';
+import { votingsState } from '../stores/voting';
 
 interface MeetingConfirmPathParams {
   meetingId: string;
@@ -21,9 +31,44 @@ export function MeetingConfirm() {
     queryFn: () => getMeeting(meetingId),
   });
 
+  const setVotings = useSetRecoilState<Voting[]>(votingsState);
+  const {
+    handleClickVoteTable: handleVoteTableClickHightlight,
+    userList,
+    voteTableDataList,
+  } = useMeetingView(meeting);
+
+  const [selectedSlot, setSelectedSlot] = useState<VotingSlot>();
+
+  // TODO: Recoil로 비동기 데이터 가져오는 것 대체
+  useEffect(() => {
+    (async () => {
+      if (!meetingId) {
+        return;
+      }
+
+      const data = await getVotings(meetingId);
+      setVotings(data);
+    })();
+  }, [setVotings, meetingId]);
+
   if (isLoading || isError) {
     return null;
   }
+
+  const handleClickVoteTable = (
+    date: Dayjs,
+    checked: boolean,
+    target: VoteTableVoting,
+    slot: VotingSlot,
+  ) => {
+    if (selectedSlot && isSameSlot(selectedSlot, slot)) {
+      setSelectedSlot(undefined);
+    } else {
+      setSelectedSlot(slot);
+    }
+    handleVoteTableClickHightlight(date, checked, target, slot);
+  };
 
   return (
     <Page>
@@ -33,12 +78,12 @@ export function MeetingConfirm() {
         </HeaderContainer>
       </Header>
       <Contents>
-        {/* <UserList users={userList} onClick={handleClickUserList} />
+        <UserList users={userList} />
         <VoteTable
           onClick={handleClickVoteTable}
           data={voteTableDataList}
           headers={meeting.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
-        /> */}
+        />
       </Contents>
       <Footer>
         <FullHeightButtonGroup
@@ -57,6 +102,7 @@ export function MeetingConfirm() {
           </Button>
           <Button
             color="primary"
+            disabled={!selectedSlot}
             onClick={() => {
               console.log('모임시간 확정');
             }}

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -94,7 +94,10 @@ export function MeetingConfirm() {
     <Page>
       <Header>
         <HeaderContainer>
-          <h1>{meeting.name}</h1>
+          <div>
+            <h1>{meeting.name}</h1>
+            <h2>모임시간을 골라서 확정해주세요.</h2>
+          </div>
         </HeaderContainer>
       </Header>
       <Contents>

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -15,6 +15,7 @@ import { MeetingType } from '../constants/meeting';
 import { useMeetingView } from '../hooks/useMeetingView';
 import { isSameSlot } from '../hooks/useMeetingVote';
 import { votingsState } from '../stores/voting';
+import { CheckConfirmModal } from '../templates/MeetingView/CheckConfirmModal';
 
 interface MeetingConfirmPathParams {
   meetingId: string;
@@ -41,6 +42,7 @@ export function MeetingConfirm() {
   } = useMeetingView(meeting);
 
   const [selectedSlot, setSelectedSlot] = useState<VotingSlot>();
+  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
 
   // TODO: Recoil로 비동기 데이터 가져오는 것 대체
   useEffect(() => {
@@ -72,7 +74,7 @@ export function MeetingConfirm() {
     handleVoteTableClickHightlight(date, checked, target, slot);
   };
 
-  const handleClickConfirmButton = () => {
+  const handleConfirm = () => {
     // TODO: 모임시간 확정 API 호출
     navigate(`/meetings/${meetingId}/result`);
   };
@@ -107,11 +109,24 @@ export function MeetingConfirm() {
           >
             취소하기
           </Button>
-          <Button color="primary" disabled={!selectedSlot} onClick={handleClickConfirmButton}>
+          <Button
+            color="primary"
+            disabled={!selectedSlot}
+            onClick={() => {
+              setShowConfirmModal(true);
+            }}
+          >
             모임시간 확정
           </Button>
         </FullHeightButtonGroup>
       </Footer>
+      <CheckConfirmModal
+        show={showConfirmModal}
+        onConfirm={handleConfirm}
+        onCancel={() => {
+          setShowConfirmModal(false);
+        }}
+      />
     </Page>
   );
 }

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -2,7 +2,7 @@ import { Button } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
@@ -21,6 +21,8 @@ interface MeetingConfirmPathParams {
 }
 
 export function MeetingConfirm() {
+  const navigate = useNavigate();
+
   const { meetingId } = useParams<keyof MeetingConfirmPathParams>() as MeetingConfirmPathParams;
   const {
     data: meeting,
@@ -70,6 +72,11 @@ export function MeetingConfirm() {
     handleVoteTableClickHightlight(date, checked, target, slot);
   };
 
+  const handleClickConfirmButton = () => {
+    // TODO: 모임시간 확정 API 호출
+    navigate(`/meetings/${meetingId}/result`);
+  };
+
   return (
     <Page>
       <Header>
@@ -95,18 +102,12 @@ export function MeetingConfirm() {
           <Button
             color="secondary"
             onClick={() => {
-              console.log('취소하기');
+              navigate(`/meetings/${meetingId}`);
             }}
           >
             취소하기
           </Button>
-          <Button
-            color="primary"
-            disabled={!selectedSlot}
-            onClick={() => {
-              console.log('모임시간 확정');
-            }}
-          >
+          <Button color="primary" disabled={!selectedSlot} onClick={handleClickConfirmButton}>
             모임시간 확정
           </Button>
         </FullHeightButtonGroup>

--- a/src/templates/MeetingView/CheckConfirmModal.tsx
+++ b/src/templates/MeetingView/CheckConfirmModal.tsx
@@ -5,13 +5,20 @@ import { CenterContentModal } from '../../components/CenterContentModal';
 import { CenteredButtonContainer, ConfirmModalContainer } from '../MeetingEdit/styled';
 import { ModalTopRightButton } from './styled';
 
+type VoidCallback = () => void;
+type VoidPromiseCallback = () => Promise<void>;
+
 interface Props {
   show: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
+  onConfirm: VoidCallback | VoidPromiseCallback;
+  onCancel: VoidCallback;
 }
 
 export function CheckConfirmModal({ show, onConfirm, onCancel }: Props) {
+  const handleClickConfirmButton = () => {
+    onConfirm();
+  };
+
   return (
     <CenterContentModal open={show} width={330} height={230}>
       <ConfirmModalContainer>
@@ -27,7 +34,11 @@ export function CheckConfirmModal({ show, onConfirm, onCancel }: Props) {
           <CloseIcon />
         </ModalTopRightButton>
         <CenteredButtonContainer>
-          <Button variant="contained" style={{ width: 200, height: 48 }} onClick={onConfirm}>
+          <Button
+            variant="contained"
+            style={{ width: 200, height: 48 }}
+            onClick={handleClickConfirmButton}
+          >
             확인
           </Button>
         </CenteredButtonContainer>

--- a/src/templates/MeetingView/CheckConfirmModal.tsx
+++ b/src/templates/MeetingView/CheckConfirmModal.tsx
@@ -1,6 +1,7 @@
 import { Close as CloseIcon } from '@mui/icons-material';
 import { Box, Button, Typography } from '@mui/material';
 
+import { VotingSlot } from '../../apis/votes';
 import { CenterContentModal } from '../../components/CenterContentModal';
 import { CenteredButtonContainer, ConfirmModalContainer } from '../MeetingEdit/styled';
 import { ModalTopRightButton } from './styled';
@@ -10,11 +11,16 @@ type VoidPromiseCallback = () => Promise<void>;
 
 interface Props {
   show: boolean;
+  slot?: VotingSlot;
   onConfirm: VoidCallback | VoidPromiseCallback;
   onCancel: VoidCallback;
 }
 
-export function CheckConfirmModal({ show, onConfirm, onCancel }: Props) {
+export function CheckConfirmModal({ show, slot, onConfirm, onCancel }: Props) {
+  const slotDateText = slot?.date.format('YYYY년 MM월 DD일') ?? '';
+  const slotMealText = slot?.meal ? getMealLabel(slot.meal) : '';
+  const slotDescription = `${slotDateText} ${slotMealText}`;
+
   const handleClickConfirmButton = () => {
     onConfirm();
   };
@@ -30,9 +36,9 @@ export function CheckConfirmModal({ show, onConfirm, onCancel }: Props) {
             확정한 날짜는 돌이킬 수 없습니다.
           </Typography>
         </Box>
-        <ModalTopRightButton onClick={onCancel}>
-          <CloseIcon />
-        </ModalTopRightButton>
+        <Box style={{ textAlign: 'center', paddingBottom: '8px' }}>
+          <Typography variant="h6">{slotDescription}</Typography>
+        </Box>
         <CenteredButtonContainer>
           <Button
             variant="contained"
@@ -42,7 +48,21 @@ export function CheckConfirmModal({ show, onConfirm, onCancel }: Props) {
             확인
           </Button>
         </CenteredButtonContainer>
+        <ModalTopRightButton onClick={onCancel}>
+          <CloseIcon />
+        </ModalTopRightButton>
       </ConfirmModalContainer>
     </CenterContentModal>
   );
+}
+
+function getMealLabel(meal: 'lunch' | 'dinner') {
+  if (meal === 'lunch') {
+    return '점심';
+  }
+  if (meal === 'dinner') {
+    return '저녁';
+  }
+
+  return '';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -612,6 +612,19 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.0.5.tgz#d5c65626add4c3c185a89aa5bd38b1e42daec075"
   integrity sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==
 
+"@tanstack/query-core@4.29.19":
+  version "4.29.19"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.19.tgz#49ccbd0606633d1e55baf3b91ab7cc7aef411b1d"
+  integrity sha512-uPe1DukeIpIHpQi6UzIgBcXsjjsDaLnc7hF+zLBKnaUlh7jFE/A+P8t4cU4VzKPMFB/C970n/9SxtpO5hmIRgw==
+
+"@tanstack/react-query@^4.29.19":
+  version "4.29.19"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.29.19.tgz#6ba187f2d0ea36ae83ff1f67068f53c88ce7b228"
+  integrity sha512-XiTIOHHQ5Cw1WUlHaD4fmVUMhoWjuNJlAeJGq7eM4BraI5z7y8WkZO+NR8PSuRnQGblpuVdjClQbDFtwxTtTUw==
+  dependencies:
+    "@tanstack/query-core" "4.29.19"
+    use-sync-external-store "^1.2.0"
+
 "@types/cookie@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
@@ -3293,6 +3306,11 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 util-deprecate@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Background

- 모임시간을 골라서 확정하는 UX로 변경됨에 따라서 모임시간 확정 페이지 추가 필요

## Implementations

- 모임시간 slot 선택 시 참석자 hightlight
- 모임시간 확정하기 버튼 클릭 시 확정안내 팝업 노출
- admin 로그인이 안되어있는 경우 보기 페이지나 신규 페이지로 redirect 하도록 권한처리