### PR TITLE
confirmMeeting API 시 slot을 객체로 다시 감싸지 않도록 수정

### DIFF
--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -39,13 +39,9 @@ export const confirmMeeting = async (meetingId: string, slot: VotingSlot) => {
     throw new Error('adminToken is not set');
   }
 
-  await api.post(
-    `/meetings/${meetingId}/confirm`,
-    { slot },
-    {
-      headers: {
-        Authorization: `Bearer ${adminToken}`,
-      },
+  await api.post(`/meetings/${meetingId}/confirm`, slot, {
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
     },
-  );
+  });
 };


### PR DESCRIPTION
- slot이 이미 객체이므로 그대로 전달되도록 `{ slot }` -> `slot`으로 수정

  https://github.com/Team-Panopticon/TBD-server/pull/37