### PR TITLE
투표 페이지 로직 오류 수정

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -38,11 +38,7 @@ const router = createBrowserRouter([
   },
   {
     path: 'meetings/:meetingId/vote',
-    element: (
-      <ProtectedAdminRoute>
-        <MeetingVote />
-      </ProtectedAdminRoute>
-    ),
+    element: <MeetingVote />,
   },
   {
     path: 'meetings/:meetingId/modify',

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -16,19 +16,28 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
   );
 
   const votings = useRecoilValue(votingsState);
+  const otherUserVotings = votings.filter((voting) => voting.id !== currentUser?.id);
+
   // TODO: 신규 유저 외에 기존 유저 선택 시 로직 반영
-  const newUserVoting: Voting = {
+  const currentVoting: Voting = {
     id: currentUser?.id ?? 'newUser',
     username: currentUser?.username ?? 'newUser',
     dateType: meeting?.type === MeetingType.date ? currentUserVotingSlots : [],
     mealType: meeting?.type === MeetingType.meal ? currentUserVotingSlots : [],
   };
-  const currentVoting = currentUserVotingSlots.length > 0 ? newUserVoting : undefined;
+
+  const isNewUser = currentUser === undefined;
+  const hasNewUserNotVoted = isNewUser && currentUserVotingSlots.length === 0;
 
   // voteTableDataList는 userMap, currentUser, 마지막 클릭된 slot / userName의 파생 상태
   const voteTableDataList = meeting?.dates.map(dayjs).map<VoteTableRowData>((day) => ({
     date: day,
-    votings: getVotings(meeting.type, day, votings, currentVoting),
+    votings: getVotings(
+      meeting.type,
+      day,
+      otherUserVotings,
+      hasNewUserNotVoted ? undefined : currentVoting,
+    ),
   }));
 
   const handleClickVoteTableSlot = (

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -17,12 +17,13 @@ export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
 
   const votings = useRecoilValue(votingsState);
   // TODO: 신규 유저 외에 기존 유저 선택 시 로직 반영
-  const currentVoting: Voting = {
+  const newUserVoting: Voting = {
     id: currentUser?.id ?? 'newUser',
     username: currentUser?.username ?? 'newUser',
     dateType: meeting?.type === MeetingType.date ? currentUserVotingSlots : [],
     mealType: meeting?.type === MeetingType.meal ? currentUserVotingSlots : [],
   };
+  const currentVoting = currentUserVotingSlots.length > 0 ? newUserVoting : undefined;
 
   // voteTableDataList는 userMap, currentUser, 마지막 클릭된 slot / userName의 파생 상태
   const voteTableDataList = meeting?.dates.map(dayjs).map<VoteTableRowData>((day) => ({

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -5,12 +5,12 @@ import { GetMeetingResponse } from '../apis/types';
 import { Voting, VotingSlot } from '../apis/votes';
 import { VoteTableRowData, VoteTableVoting } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
-import { currentUserState } from '../stores/currentUser';
+import { currentUserStateOf } from '../stores/currentUser';
 import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { getVotings, votingsState } from '../stores/voting';
 
 export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValue(currentUserStateOf(meeting?.id ?? ''));
   const [currentUserVotingSlots, setCurrentUserVotingSlots] = useRecoilState(
     currentUserVotingSlotsState,
   );

--- a/src/hooks/useMeetingVote.ts
+++ b/src/hooks/useMeetingVote.ts
@@ -5,12 +5,12 @@ import { GetMeetingResponse } from '../apis/types';
 import { Voting, VotingSlot } from '../apis/votes';
 import { VoteTableRowData, VoteTableVoting } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
-import { currentUserStateOf } from '../stores/currentUser';
+import { currentUserStateFamily } from '../stores/currentUser';
 import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { getVotings, votingsState } from '../stores/voting';
 
 export const useMeetingViewVoteMode = (meeting?: GetMeetingResponse) => {
-  const currentUser = useRecoilValue(currentUserStateOf(meeting?.id ?? ''));
+  const currentUser = useRecoilValue(currentUserStateFamily(meeting?.id ?? ''));
   const [currentUserVotingSlots, setCurrentUserVotingSlots] = useRecoilState(
     currentUserVotingSlotsState,
   );

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -14,7 +14,7 @@ import { VoteTable } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
 import { useMeetingView } from '../hooks/useMeetingView';
 import { adminTokenState } from '../stores/adminToken';
-import { currentUserState } from '../stores/currentUser';
+import { currentUserStateOf } from '../stores/currentUser';
 import { showVoteSuccessPopupState } from '../stores/showVoteSuccessPopup';
 import { votingsState } from '../stores/voting';
 import { Dropdown } from '../templates/MeetingView/Dropdown/Dropdown';
@@ -29,7 +29,7 @@ export function MeetingView() {
   const { meetingId } = useParams<keyof MeetingViewPathParams>() as MeetingViewPathParams;
   const setVotings = useSetRecoilState<Voting[]>(votingsState);
   const [showVoteSuccessPopup, setShowVoteSuccessPopup] = useRecoilState(showVoteSuccessPopupState);
-  const currentUser = useRecoilValue(currentUserState);
+  const currentUser = useRecoilValue(currentUserStateOf(meetingId));
 
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
   const [showPasswordModal, setShowPasswordModal] = useState<boolean>(false);

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -14,7 +14,7 @@ import { VoteTable } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
 import { useMeetingView } from '../hooks/useMeetingView';
 import { adminTokenState } from '../stores/adminToken';
-import { currentUserStateOf } from '../stores/currentUser';
+import { currentUserStateFamily } from '../stores/currentUser';
 import { showVoteSuccessPopupState } from '../stores/showVoteSuccessPopup';
 import { votingsState } from '../stores/voting';
 import { Dropdown } from '../templates/MeetingView/Dropdown/Dropdown';
@@ -29,7 +29,7 @@ export function MeetingView() {
   const { meetingId } = useParams<keyof MeetingViewPathParams>() as MeetingViewPathParams;
   const setVotings = useSetRecoilState<Voting[]>(votingsState);
   const [showVoteSuccessPopup, setShowVoteSuccessPopup] = useRecoilState(showVoteSuccessPopupState);
-  const currentUser = useRecoilValue(currentUserStateOf(meetingId));
+  const currentUser = useRecoilValue(currentUserStateFamily(meetingId));
 
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
   const [showPasswordModal, setShowPasswordModal] = useState<boolean>(false);

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -12,7 +12,7 @@ import { UserList, UserListData } from '../components/UserList/UserList';
 import { VoteTable } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
 import { useMeetingViewVoteMode } from '../hooks/useMeetingVote';
-import { currentUserStateOf } from '../stores/currentUser';
+import { currentUserStateFamily } from '../stores/currentUser';
 import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { showVoteSuccessPopupState } from '../stores/showVoteSuccessPopup';
 import { userListState, votingsState } from '../stores/voting';
@@ -25,8 +25,8 @@ interface MeetingVoteRouteParams {
 export function MeetingVote() {
   const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
 
-  const [currentUser, setCurrentUser] = useRecoilState(currentUserStateOf(meetingId));
-  const resetCurrentUser = useResetRecoilState(currentUserStateOf(meetingId));
+  const [currentUser, setCurrentUser] = useRecoilState(currentUserStateFamily(meetingId));
+  const resetCurrentUser = useResetRecoilState(currentUserStateFamily(meetingId));
   const setCurrentUserVotingSlots = useSetRecoilState(currentUserVotingSlotsState);
   const setShowVoteSuccessPopup = useSetRecoilState(showVoteSuccessPopupState);
   const isNewUser = !currentUser;
@@ -34,6 +34,7 @@ export function MeetingVote() {
   const [meeting, setMeeting] = useState<GetMeetingResponse>();
   const [votings, setVotings] = useRecoilState(votingsState);
   const userList = useRecoilValue(userListState);
+
   const [showUsernameModal, setShowUsernameModal] = useState<boolean>(false);
 
   const navigate = useNavigate();

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -43,13 +43,17 @@ export function MeetingVote() {
 
   useEffect(() => {
     (async () => {
-      const data = await getVotings(meetingId);
-      setVotings(data);
+      const votingsData = await getVotings(meetingId);
+      setVotings(votingsData);
 
       const meetingData = await getMeeting(meetingId);
       setMeeting(meetingData);
+
+      const currentUserVoting = votingsData.find((voting) => voting.id === currentUser?.id);
+      const currentUserVotingSlots = currentUserVoting?.[meetingData.type];
+      setCurrentUserVotingSlots(currentUserVotingSlots ?? []);
     })();
-  }, [meetingId, setVotings]);
+  }, [meetingId, setVotings, setCurrentUserVotingSlots, currentUser]);
 
   const handleClickUser = (checked: boolean, clickedUser: UserListData) => {
     if (!meeting) {

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -12,7 +12,7 @@ import { UserList, UserListData } from '../components/UserList/UserList';
 import { VoteTable } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
 import { useMeetingViewVoteMode } from '../hooks/useMeetingVote';
-import { currentUserState } from '../stores/currentUser';
+import { currentUserStateOf } from '../stores/currentUser';
 import { currentUserVotingSlotsState } from '../stores/currentUserVotingSlots';
 import { showVoteSuccessPopupState } from '../stores/showVoteSuccessPopup';
 import { userListState, votingsState } from '../stores/voting';
@@ -25,8 +25,8 @@ interface MeetingVoteRouteParams {
 export function MeetingVote() {
   const { meetingId } = useParams<keyof MeetingVoteRouteParams>() as MeetingVoteRouteParams;
 
-  const [currentUser, setCurrentUser] = useRecoilState(currentUserState);
-  const resetCurrentUser = useResetRecoilState(currentUserState);
+  const [currentUser, setCurrentUser] = useRecoilState(currentUserStateOf(meetingId));
+  const resetCurrentUser = useResetRecoilState(currentUserStateOf(meetingId));
   const setCurrentUserVotingSlots = useSetRecoilState(currentUserVotingSlotsState);
   const setShowVoteSuccessPopup = useSetRecoilState(showVoteSuccessPopupState);
   const isNewUser = !currentUser;

--- a/src/stores/currentUser.ts
+++ b/src/stores/currentUser.ts
@@ -7,8 +7,9 @@ export interface User {
   username: string;
 }
 
-export const currentUserState = atom({
-  key: 'currentUser',
-  default: undefined,
-  effects: [localstorageEffect<User | undefined>('current_user')],
-});
+export const currentUserStateOf = (meetingId: string) =>
+  atom({
+    key: 'currentUser',
+    default: undefined,
+    effects: [localstorageEffect<User | undefined>(`meetings/${meetingId}/current_user`)],
+  });

--- a/src/stores/currentUser.ts
+++ b/src/stores/currentUser.ts
@@ -1,4 +1,4 @@
-import { atom } from 'recoil';
+import { atomFamily } from 'recoil';
 
 import { localstorageEffect } from './localstorageEffect';
 
@@ -7,9 +7,10 @@ export interface User {
   username: string;
 }
 
-export const currentUserStateOf = (meetingId: string) =>
-  atom({
-    key: 'currentUser',
-    default: undefined,
-    effects: [localstorageEffect<User | undefined>(`meetings/${meetingId}/current_user`)],
-  });
+export const currentUserStateFamily = atomFamily<User | undefined, string>({
+  key: 'currentUser',
+  default: undefined,
+  effects: (meetingId) => [
+    localstorageEffect<User | undefined>(`meetings/${meetingId}/current_user`),
+  ],
+});

--- a/src/templates/MeetingView/InputUsernameModal.tsx
+++ b/src/templates/MeetingView/InputUsernameModal.tsx
@@ -65,7 +65,7 @@ export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: 
               onClick={() => {
                 onConfirm(username);
               }}
-              disabled={invalidText !== ''}
+              disabled={username.length === 0 || invalidText !== ''}
             >
               완료
             </Button>

--- a/src/templates/MeetingView/InputUsernameModal.tsx
+++ b/src/templates/MeetingView/InputUsernameModal.tsx
@@ -5,7 +5,7 @@ import { CenterContentModal } from '../../components/CenterContentModal';
 import { FullHeightButtonGroup } from '../../components/styled';
 
 enum InvalidText {
-  EMPTY = '참석자 이름을 입력해주세요',
+  EMPTY = '이름은 한글자 이상 입력해야 합니다',
   DUP = '중복된 이름입니다',
 }
 
@@ -48,6 +48,7 @@ export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: 
               variant="outlined"
               fullWidth
               value={username}
+              placeholder="당신의 이름을 정해주세요"
               onChange={onChangeTextField}
               error={invalidText !== ''}
               helperText={invalidText}


### PR DESCRIPTION
## Summary

- 자체 데모하면서 나온 투표페이지 로직 오류 수정
- #114 
- 스타일 작업은 #111 머지된 이후에 수정

## Checklist

- [x] 투표를 했을 때 자기 투표를 보여주는 방식
    1. ~~미리 투표 인원수를 1 늘려놓는다~~
    2. 투표한 날짜에만 인원수와 투표수를 1씩 늘려놓는다
    3. ~~아예 반영하지 않는다 (버튼 색상만 반영)~~
- [x] 사용자 이름 input modal
    - [x] 처음 렌더링 시 투표하기 버튼이 disable되지 않음 → 빈 이름으로 유저 생성됨
    - [x] 무엇을 해야하는지 문구 추가되면 좋을듯 (이름을 정해주세요… 등의 문구)
- [x] 투표하기 - 수정일 때도 1을 더함
- [x] 수정하기 api 확인해보기 (동작이 안됨)
- [x] 해당 투표의 익명유저가 아닌 경우에도 localStorage에 값이 있으면 유저가 있는것처럼 취급됨
    - [x] meetingId를 저장하고, userId가 votings 안에 있는지 체크 필요