### PR TITLE
투표확정 페이지 스타일 적용

### DIFF
--- a/index.css
+++ b/index.css
@@ -21,6 +21,7 @@ time, mark, audio, video {
 	border: 0;
 	font-size: 100%;
 	font: inherit;
+	font-family: "Roboto","Helvetica","Arial",sans-serif;
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */

--- a/src/pages/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@mui/material';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
+import { Box, Button, Typography } from '@mui/material';
 import { useQuery } from '@tanstack/react-query';
 import { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
@@ -8,7 +9,7 @@ import { useSetRecoilState } from 'recoil';
 import { confirmMeeting, getMeeting } from '../apis/meetings';
 import { getVotings, Voting, VotingSlot } from '../apis/votes';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
-import { FullHeightButtonGroup } from '../components/styled';
+import { FlexVertical, FullHeightButtonGroup } from '../components/styled';
 import { UserList } from '../components/UserList/UserList';
 import { VoteTable, VoteTableVoting } from '../components/VoteTable/VoteTable';
 import { MeetingType } from '../constants/meeting';
@@ -16,6 +17,7 @@ import { useMeetingView } from '../hooks/useMeetingView';
 import { isSameSlot } from '../hooks/useMeetingVote';
 import { votingsState } from '../stores/voting';
 import { CheckConfirmModal } from '../templates/MeetingView/CheckConfirmModal';
+import { UserListLabel, UserListWrapper, VoteTableWrapper } from '../templates/MeetingView/styled';
 
 interface MeetingConfirmPathParams {
   meetingId: string;
@@ -94,19 +96,41 @@ export function MeetingConfirm() {
     <Page>
       <Header>
         <HeaderContainer>
-          <div>
-            <h1>{meeting.name}</h1>
-            <h2>모임시간을 골라서 확정해주세요.</h2>
-          </div>
+          <FlexVertical flex={1} alignItems={'center'} gap={1}>
+            <FlexVertical flex={1} gap={1} width={'100%'}>
+              <Box
+                display={'flex'}
+                flexDirection={'row'}
+                justifyContent={'center'}
+                alignItems={'center'}
+                gap={1}
+              >
+                <Typography variant="h5" fontWeight={700}>
+                  {meeting.name}
+                </Typography>
+              </Box>
+              <FlexVertical alignItems={'center'}>
+                <EventAvailableIcon sx={{ fontSize: 110 }} />
+              </FlexVertical>
+              <Typography variant="h6" fontWeight={400} align="center">
+                모임시간을 골라서 확정해주세요
+              </Typography>
+            </FlexVertical>
+          </FlexVertical>
         </HeaderContainer>
       </Header>
       <Contents>
-        <UserList users={userList} />
-        <VoteTable
-          onClick={handleClickVoteTable}
-          data={voteTableDataList}
-          headers={meeting.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
-        />
+        <UserListWrapper>
+          <UserListLabel>참석자 목록</UserListLabel>
+          <UserList users={userList} />
+        </UserListWrapper>
+        <VoteTableWrapper>
+          <VoteTable
+            onClick={handleClickVoteTable}
+            data={voteTableDataList}
+            headers={meeting.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
+          />
+        </VoteTableWrapper>
       </Contents>
       <Footer>
         <FullHeightButtonGroup

--- a/src/pages/MeetingView.tsx
+++ b/src/pages/MeetingView.tsx
@@ -96,9 +96,7 @@ export function MeetingView() {
                   {meeting.name}
                 </Typography>
                 <Dropdown
-                  onClickConfirmButton={() => {
-                    // TODO: 확정하기 api 연결
-                  }}
+                  onClickConfirmButton={handleClickConfirmButton}
                   onClickEditButton={() => {
                     // TODO: 수정하기 api 연결
                   }}

--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -154,7 +154,7 @@ export function MeetingVote() {
               <FlexVertical alignItems={'center'}>
                 <img height={110} src={WritingHands} alt="" />
               </FlexVertical>
-              <FlexVertical height={64}>
+              <FlexVertical>
                 {currentUser ? (
                   <Typography variant="h6" fontWeight={400} align="center">
                     <PrimaryBold className="primary-bold">{currentUser.username}</PrimaryBold>님의


### PR DESCRIPTION
## Summary

- 보기, 투표하기 페이지와 헤더, 아이콘, 참석자목록, 테이블 스타일 통일
- 아이콘은 figma에 정의된 것이 없어서 MUI에서 적당한 아이콘을 가져왔습니다. 혹시 다른 아이콘 선호하시는 것 있으면 말씀부탁드려요. 
- MUI 컴포넌트에만 적용되던 Roboto 폰트를 모든 DOM 요소에 글로벌로 적용

## Screenshot

<img width="375" alt="Screen Shot 2023-07-26 at 9 51 35 PM" src="https://github.com/Team-Panopticon/TBD-client/assets/32405358/6be5b83b-6d19-495b-82c3-2694eed26dc5">
