### PR TITLE
투표 생성 또는 수정 시 mealType 데이터가 dateType으로 잘못 들어가는 이슈 수정

### DIFF
--- a/src/pages/MeetingVote.tsx
+++ b/src/pages/MeetingVote.tsx
@@ -93,6 +93,10 @@ export function MeetingVote() {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   const handleClickVote = async () => {
+    if (!meeting) {
+      return;
+    }
+
     if (isNewUser) {
       setShowUsernameModal(true);
       return;
@@ -104,7 +108,7 @@ export function MeetingVote() {
       votingId: currentUser.id,
       data: {
         username: currentUser.username,
-        dateType: currentUserVotingSlots,
+        [meeting.type]: currentUserVotingSlots,
       },
     });
     setShowUsernameModal(false);
@@ -113,11 +117,15 @@ export function MeetingVote() {
   };
 
   const handleUsernameConfirm = async (username: string) => {
+    if (!meeting) {
+      return;
+    }
+
     const voting = await createVoting({
       meetingId,
       data: {
         username,
-        dateType: currentUserVotingSlots,
+        [meeting.type]: currentUserVotingSlots,
       },
     });
 


### PR DESCRIPTION
## Summary

- mealType 미팅에 대해서 정상적으로 투표가 반영되지 않는 이슈
- 투표 페이지에서 생성, 삭제 시 무조건적으로 dateType으로 API에 데이터를 제출하고 있음 -> 적합한 타입에 데이터 넣도록 수정