### PR TITLE
fix: 모임생성 > 비밀번호 모달 > 취소 시 비밀번호 초기화

### DIFF
--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -59,6 +59,13 @@ export function MeetingCreate() {
   const handlePasswordSkip = () => {
     createMeetingAndNavigate({ usePassword: false });
   };
+  const handlePasswordCancel = () => {
+    setShowPasswordModal(false);
+    setMeeting((prev) => ({
+      ...prev,
+      password: undefined,
+    }));
+  };
 
   return (
     <Page>
@@ -76,7 +83,7 @@ export function MeetingCreate() {
         password={meeting.password}
         onChange={handlePasswordChange}
         onConfirm={handlePasswordConfirm}
-        onCancel={() => setShowPasswordModal(false)}
+        onCancel={handlePasswordCancel}
         onSkip={handlePasswordSkip}
       />
     </Page>


### PR DESCRIPTION
모임 생성 - 비밀번호 입력 후 취소, 다시 입력창이 뜰 때 기존 입력 내역이 남아있음 #141

--
TEST
모임생성 > 비밀번호 모달 > 비밀번호 입력 > 취소 > 비밀번호 모달 다시 확인시 초기화 확인

close #141