### PR TITLE
fix: 모임 이름 공백 제거

### DIFF
--- a/src/components/ShareDialog/ShareDialog.tsx
+++ b/src/components/ShareDialog/ShareDialog.tsx
@@ -22,7 +22,6 @@ export function ShareDialog() {
     description: `${name}모임 투표를 부탁드려요.`,
     meetingId: target?.id || '',
   });
-  console.log(isError, serviceName, ref, isLoading);
   return (
     <>
       <Drawer anchor="bottom" open={show} onClose={closeShare}>

--- a/src/hooks/useMeetingEdit.ts
+++ b/src/hooks/useMeetingEdit.ts
@@ -16,7 +16,7 @@ export default function useMeetingEdit() {
         index: 0,
         description: '모임의 이름이 무엇인가요?',
         progress: 25,
-        title: '모임 이름',
+        title: '모임 이름 (최대 30글자)',
         type: 'name',
       },
       {

--- a/src/pages/MeetingCreate.tsx
+++ b/src/pages/MeetingCreate.tsx
@@ -41,7 +41,11 @@ export function MeetingCreate() {
 
   const createMeetingAndNavigate = async ({ usePassword }: { usePassword: boolean }) => {
     try {
-      const response = await createMeeting(meeting as ValidCreateMeetingState, usePassword);
+      const trimmedName = meeting.name?.trim();
+      const response = await createMeeting(
+        { ...meeting, name: trimmedName } as ValidCreateMeetingState,
+        usePassword,
+      );
       navigate(`/meetings/${response.id}`);
     } catch (e: unknown) {
       if (e instanceof AxiosError) {

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -31,7 +31,7 @@ export const createMeetingState = atom<CreateMeetingState>({
 
 export const validateMeetingName = (name: string) => {
   const trimmedName = name.trim();
-  return trimmedName.length > 0;
+  return trimmedName.length > 0 && trimmedName.length <= 30;
 };
 
 interface ValidateSelectedDatesProps {

--- a/src/stores/createMeeting.ts
+++ b/src/stores/createMeeting.ts
@@ -30,7 +30,8 @@ export const createMeetingState = atom<CreateMeetingState>({
 });
 
 export const validateMeetingName = (name: string) => {
-  return name.length > 0;
+  const trimmedName = name.trim();
+  return trimmedName.length > 0;
 };
 
 interface ValidateSelectedDatesProps {

--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -128,6 +128,9 @@ const getMeetingEditContent = <T extends CreateMeetingState | Meeting>(
           helperText={helperText}
           value={meeting.name ?? ''}
           onChange={(v) => {
+            if (v.target.value.length > 30) {
+              return;
+            }
             setValue((prev) => ({
               ...prev,
               name: v.target.value,


### PR DESCRIPTION
모임 생성 - 모임 이름으로 공백을 설정못하도록 & 공백에 대한 처리 추가 #151

--
TEST
- 모임 생성 > 모임이름 옆 최대 길이 표시
- 모임 생성 > 모임 이름 최대길이 30 이상 입력 불가
- 모임 생성 > trim된 모임이름으로 모임 생성

close #151 