### PR TITLE
fix: VoteTable에서 날짜별 row를 정렬해서 노출

### DIFF
--- a/src/components/VoteTable/VoteTable.tsx
+++ b/src/components/VoteTable/VoteTable.tsx
@@ -46,6 +46,7 @@ export const VoteTable: React.FC<Props> = (props) => {
   const { data, onClick, style, className, headers } = props;
 
   const isHideVotingStatus = data.some((item) => item.votings.some((vote) => vote.checked));
+  const sortedData = [...data].sort((a, b) => a.date.diff(b.date));
 
   return (
     <VoteTableContainer className={className} style={style}>
@@ -57,7 +58,7 @@ export const VoteTable: React.FC<Props> = (props) => {
         ))}
       </Header>
       <ContentWrapper>
-        {data.map((item, idx) => (
+        {sortedData.map((item, idx) => (
           <VoteTableContent
             isHideVotingStatus={isHideVotingStatus}
             onClick={onClick}


### PR DESCRIPTION
## Summary

- DB, 서버쪽에서 데이터를 보낼 때 정렬해서 보내지 않고 있음
- 프론트에서 vote table 노출 시 데이터 정렬해서 표시