### PR TITLE
투표 페이지 - 투표모드 - 유저 명 공백 처리, trim 적용 ,  투표 현황 유저 이름이 길 경우 UI가 깨짐 

### DIFF
--- a/src/components/UserList/styled.ts
+++ b/src/components/UserList/styled.ts
@@ -22,4 +22,5 @@ export const StyledChip = styled(Chip)({
 export const ChipInnerText = styled('div')({
   textOverflow: 'ellipsis',
   overflow: 'hidden',
+  wordBreak: 'keep-all',
 });

--- a/src/templates/MeetingView/InputUsernameModal.tsx
+++ b/src/templates/MeetingView/InputUsernameModal.tsx
@@ -24,7 +24,7 @@ export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: 
     const value = e.target.value.slice(0, 20);
     setUsername(value);
 
-    if (value.length === 0) {
+    if (value.trim().length === 0) {
       setInvalidText(InvalidText.EMPTY);
     } else if (!validation(value)) {
       setInvalidText(InvalidText.DUP);
@@ -41,7 +41,7 @@ export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: 
       <CenterContentModal open={show} width={320} height={170}>
         <div style={{ position: 'relative', height: '100%' }}>
           <div style={{ padding: 25 }}>
-            <InputLabel shrink>참석자 이름</InputLabel>
+            <InputLabel shrink>참석자 이름 (최대 20자)</InputLabel>
             <TextField
               id="userId"
               size="small"
@@ -65,9 +65,9 @@ export function InputUsernameModal({ show, usernameList, onConfirm, onCancel }: 
             </Button>
             <Button
               onClick={() => {
-                onConfirm(username);
+                onConfirm(username.trim());
               }}
-              disabled={username.length === 0 || invalidText !== ''}
+              disabled={username.trim().length === 0 || invalidText !== ''}
             >
               완료
             </Button>


### PR DESCRIPTION
투표 페이지 - 투표모드 - 유저 명 공백 처리, trim 적용 #159
투표 페이지 - 투표 현황 유저 이름이 길 경우 UI가 깨짐 #153


-- TEST
투표모드 > 유저 이름 한글로 길게 입력 > chip 말줄임표 처리
투표모드 > 유저이름 앞뒤로 공백입력 > trim 처리된 유저 이름 등록

close #159 , #153 