### PR TITLE
fix: 확정페이지에서 목데이터가 아닌 실제 데이터랑 연동

### DIFF
--- a/src/apis/meetings.ts
+++ b/src/apis/meetings.ts
@@ -19,9 +19,17 @@ const meetingStateToRequest = (
 };
 
 const meetingResponseToState = (state: MeetingResponse): Meeting => {
+  const confirmedDateType: VotingSlot | undefined = state.confirmedDateType
+    ? {
+        date: dayjs(state.confirmedDateType.date),
+        meal: state.confirmedDateType.meal,
+      }
+    : undefined;
+
   return {
     ...state,
     dates: state.dates.map((date) => dayjs(date)),
+    confirmedDateType,
   };
 };
 

--- a/src/apis/types.ts
+++ b/src/apis/types.ts
@@ -1,7 +1,7 @@
 import { Dayjs } from 'dayjs';
 
 import { MeetingAdminAccess, MeetingStatus, MeetingType } from '../constants/meeting';
-import { VotingSlotResponse } from './votes';
+import { VotingSlot, VotingSlotResponse } from './votes';
 
 export type ISODateTime = string;
 
@@ -19,6 +19,7 @@ export interface MeetingResponse extends CreateMeetingRequest {
   adminAccess: MeetingAdminAccess;
 }
 
-export type Meeting = Omit<MeetingResponse, 'dates'> & {
+export type Meeting = Omit<MeetingResponse, 'dates' | 'confirmedDateType'> & {
   dates: Dayjs[];
+  confirmedDateType?: VotingSlot;
 };

--- a/src/hooks/useMeetingResult.ts
+++ b/src/hooks/useMeetingResult.ts
@@ -1,13 +1,61 @@
 import { useRecoilValue } from 'recoil';
 
-import { confiremdUserListSelector, missedUserListSelector } from '../stores/voting';
+import { Meeting } from '../apis/types';
+import { Voting, VotingSlot } from '../apis/votes';
+import { UserListData } from '../components/UserList/UserList';
+import { MeetingType } from '../constants/meeting';
+import { votingsState } from '../stores/voting';
 
-export const useMeetingResult = () => {
-  const missedUserList = useRecoilValue(missedUserListSelector);
-  const confirmedUserList = useRecoilValue(confiremdUserListSelector);
+export const useMeetingResult = (meeting?: Meeting) => {
+  const votings = useRecoilValue(votingsState);
 
   return {
-    confirmedUserList,
-    missedUserList,
+    confirmedUserList: getConfirmedUserList(votings, meeting),
+    missedUserList: getMissedUserList(votings, meeting),
   };
+};
+
+const getMissedUserList = (votings: Voting[], meeting?: Meeting) => {
+  const meetingType = meeting?.type || MeetingType.date;
+
+  return votings
+    .filter((voting) => {
+      const votingDates = voting[meetingType];
+
+      return !votingDates?.find((meal: VotingSlot) => {
+        return meal.date.isSame(meeting?.confirmedDateType?.date, 'day');
+      });
+    })
+    .map<UserListData>((voting) => {
+      const { username, id } = voting;
+
+      return {
+        id,
+        username,
+        checked: false,
+        focused: false,
+      };
+    });
+};
+
+const getConfirmedUserList = (votings: Voting[], meeting?: Meeting) => {
+  const meetingType = meeting?.type || MeetingType.date;
+
+  return votings
+    .filter((voting) => {
+      const votingDates = voting[meetingType];
+
+      return !!votingDates?.find((meal: VotingSlot) => {
+        return meal.date.isSame(meeting?.confirmedDateType?.date, 'day');
+      });
+    })
+    .map<UserListData>((voting) => {
+      const { username, id } = voting;
+      return {
+        id,
+        username,
+        checked: true,
+        focused: false,
+      };
+    });
 };

--- a/src/pages/MeetingResult.tsx
+++ b/src/pages/MeetingResult.tsx
@@ -2,19 +2,23 @@ import { Button } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
 import { Meeting } from '../apis/types';
+import { getVotings, Voting } from '../apis/votes';
 import { HifiveIcon } from '../components/IconComponent/HiFive';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
 import { FlexVertical, FullHeightButtonGroup } from '../components/styled';
 import { UserList } from '../components/UserList/UserList';
 import { useMeetingResult } from '../hooks/useMeetingResult';
 import useShare from '../hooks/useShare';
+import { votingsState } from '../stores/voting';
 
 export function MeetingResult() {
   const navigate = useNavigate();
   const [meeting, setMeeting] = useState<Meeting>();
+  const [, setVotings] = useRecoilState<Voting[]>(votingsState);
   const { meetingId } = useParams();
   const { openShare, setTarget } = useShare();
 
@@ -24,12 +28,14 @@ export function MeetingResult() {
         return;
       }
 
-      const meetingData = await getMeeting(meetingId);
+      const [meetingData, data] = await Promise.all([getMeeting(meetingId), getVotings(meetingId)]);
+
+      setVotings(data);
       setMeeting(meetingData);
       setTarget(meetingData);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [meetingId]);
+  }, [setVotings, meetingId]);
 
   const { confirmedUserList, missedUserList } = useMeetingResult();
 

--- a/src/pages/MeetingResult.tsx
+++ b/src/pages/MeetingResult.tsx
@@ -2,39 +2,34 @@ import { Button } from '@mui/material';
 import Typography from '@mui/material/Typography';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
 
 import { getMeeting } from '../apis/meetings';
 import { Meeting } from '../apis/types';
-import { getVotings, Voting } from '../apis/votes';
 import { HifiveIcon } from '../components/IconComponent/HiFive';
 import { Contents, Footer, Header, HeaderContainer, Page } from '../components/pageLayout';
 import { FlexVertical, FullHeightButtonGroup } from '../components/styled';
 import { UserList } from '../components/UserList/UserList';
 import { useMeetingResult } from '../hooks/useMeetingResult';
 import useShare from '../hooks/useShare';
-import { votingsState } from '../stores/voting';
 
 export function MeetingResult() {
   const navigate = useNavigate();
   const [meeting, setMeeting] = useState<Meeting>();
   const { meetingId } = useParams();
-  const [votings, setVotings] = useRecoilState<Voting[]>(votingsState);
   const { openShare, setTarget } = useShare();
+
   useEffect(() => {
     (async () => {
       if (!meetingId) {
         return;
       }
 
-      const data = await getVotings(meetingId);
-      setVotings(data);
-
       const meetingData = await getMeeting(meetingId);
       setMeeting(meetingData);
       setTarget(meetingData);
     })();
-  }, [setVotings, meetingId]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [meetingId]);
 
   const { confirmedUserList, missedUserList } = useMeetingResult();
 
@@ -64,10 +59,10 @@ export function MeetingResult() {
                 </FlexVertical>
                 <FlexVertical>
                   <Typography variant="h2" color={'primary'} fontWeight={500} align="center">
-                    {'11/4'}
+                    {meeting?.confirmedDateType?.date.format('M/DD')}
                   </Typography>
                   <Typography variant="h5" color={'primary'} align="center">
-                    {'[화요일]'}
+                    {`[${meeting?.confirmedDateType?.date.format('dddd') || ''}]`}
                   </Typography>
                 </FlexVertical>
               </FlexVertical>

--- a/src/stores/voting.ts
+++ b/src/stores/voting.ts
@@ -2,7 +2,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import { atom, selector, selectorFamily } from 'recoil';
 
 import { Meeting } from '../apis/types';
-import { Voting, VotingSlot, VotingSlotResponse } from '../apis/votes';
+import { Voting } from '../apis/votes';
 import { UserListData } from '../components/UserList/UserList';
 import { VoteTableRowData, VoteTableVoting } from '../components/VoteTable/VoteTable';
 import { MealType, MeetingType } from '../constants/meeting';
@@ -148,58 +148,5 @@ export const userListState = selector({
         focused: false,
       };
     });
-  },
-});
-
-// todo: meeting respose 에서 가져오기
-const TempConfirmedVoting: VotingSlotResponse = {
-  date: '2023-06-08T15:00:00.000Z',
-};
-export const missedUserListSelector = selector({
-  key: 'missedUserListSelector',
-  get: ({ get }) => {
-    const votings = get(votingsState);
-
-    return votings
-      .filter((voting) => {
-        const { mealType } = voting;
-        return !mealType?.find((meal: VotingSlot) => {
-          return meal.date.isSame(dayjs(TempConfirmedVoting.date), 'day');
-        });
-      })
-      .map<UserListData>((voting) => {
-        const { username, id } = voting;
-
-        return {
-          id,
-          username,
-          checked: false,
-          focused: false,
-        };
-      });
-  },
-});
-
-export const confiremdUserListSelector = selector({
-  key: 'confiremdUserListSelector',
-  get: ({ get }) => {
-    const votings = get(votingsState);
-
-    return votings
-      .filter((voting) => {
-        const { mealType } = voting;
-        return !!mealType?.find((meal: VotingSlot) => {
-          return meal.date.isSame(dayjs(TempConfirmedVoting.date), 'day');
-        });
-      })
-      .map<UserListData>((voting) => {
-        const { username, id } = voting;
-        return {
-          id,
-          username,
-          checked: true,
-          focused: false,
-        };
-      });
   },
 });


### PR DESCRIPTION
## 주요변경사항

- 실제 데이터로 확정날짜, 요일이 표시되도록 했습니다.
- 실제 데이터로 참석 가능,불가능 유저 리스트가 표시되도록 했습니다.
   - seletor를 없애고 useMeetingResult 훅에서 Meeting 데이터 기준으로 filtering 해줬습니다.

close #166 