### PR TITLE
reactQuery refetchOnWindowFocus 옵션 false 전역 설정 추가

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,7 +13,13 @@ if (process.env.NODE_ENV === 'development' && import.meta.env.VITE_USE_MSW) {
   worker.start();
 }
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
- reactQuery의 queryClient에 refetchOnWindowFocus 옵션을 false로 전역 설정되도록 추가

  수정하기 페이지에서 focus를 다시 얻었을 때 서버 데이터를 다시 받아오며 수정 사항이 초기화되는 이슈 수정

close #183 