### PR TITLE
fix: 모바일 done 클릭 시 미팅 이름에 대한 밸리데이션이 필요하도록 수정

### DIFF
--- a/src/templates/MeetingEdit/MeetingEditTemplate.tsx
+++ b/src/templates/MeetingEdit/MeetingEditTemplate.tsx
@@ -131,7 +131,7 @@ const getMeetingEditContent = <T extends CreateMeetingState | Meeting>(
           value={meeting.name ?? ''}
           onBlur={() => {
             // Mobile Browser
-            if (hasTouchScreen) {
+            if (meeting.name && validateMeetingName(meeting.name) && hasTouchScreen) {
               const meetingDateStepNo = 1;
               setStep?.((currentStepNo) => Math.max(currentStepNo, meetingDateStepNo));
             }


### PR DESCRIPTION
## 주요변경사항

 - 모바일에서 done 버튼 혹은 블러 처리 되는 경우에 미팅 이름에 대한 밸리데이션을 하도록 추가했습니다.