### PR TITLE
모임 생성/수정 페이지에서 선택된 모임유형의 테두리 색상을 버튼 색상과 통일

### DIFF
--- a/src/templates/MeetingEdit/SelectMeetingType.tsx
+++ b/src/templates/MeetingEdit/SelectMeetingType.tsx
@@ -1,7 +1,7 @@
 import { ToggleButton } from '@mui/material';
 
 import { MeetingType } from '../../constants/meeting';
-import { customButtonStyle, CustomTogglebuttonGroup } from './styled';
+import { CustomTogglebuttonGroup, getCustomButtonStyle } from './styled';
 
 interface Props {
   value: MeetingType;
@@ -23,10 +23,16 @@ export function SelectMeetingType({ value, onChange }: Props) {
       value={value}
       fullWidth
     >
-      <ToggleButton style={customButtonStyle} value={MeetingType.date}>
+      <ToggleButton
+        style={getCustomButtonStyle(value === MeetingType.date)}
+        value={MeetingType.date}
+      >
         날짜만
       </ToggleButton>
-      <ToggleButton style={customButtonStyle} value={MeetingType.meal}>
+      <ToggleButton
+        style={getCustomButtonStyle(value === MeetingType.meal)}
+        value={MeetingType.meal}
+      >
         점심/저녁
       </ToggleButton>
     </CustomTogglebuttonGroup>

--- a/src/templates/MeetingEdit/styled.tsx
+++ b/src/templates/MeetingEdit/styled.tsx
@@ -1,5 +1,7 @@
 import { Button, LinearProgress, styled, ToggleButtonGroup } from '@mui/material';
 
+import { PRIMARY_COLOR, SECONDARY_COLOR } from '../../theme';
+
 export const InputContainer = styled('div')({
   display: 'flex',
   flexDirection: 'column',
@@ -16,10 +18,10 @@ export const CustomTogglebuttonGroup = styled(ToggleButtonGroup)({
   gap: '25px',
 });
 
-export const customButtonStyle: React.CSSProperties = {
-  border: '1px solid #D9D9D9',
+export const getCustomButtonStyle = (isSelected: boolean): React.CSSProperties => ({
+  border: `1px solid ${isSelected ? PRIMARY_COLOR : SECONDARY_COLOR}`,
   borderRadius: '4px',
-};
+});
 
 // StyledComponent for MeetingEditTemplate
 export const BorderLinearProgress = styled(LinearProgress)({

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,7 @@
 import { createTheme, ThemeOptions } from '@mui/material/styles';
 
-const PRIMARY_COLOR = '#66D6B4';
-const SECONDARY_COLOR = '#d9d9d9';
+export const PRIMARY_COLOR = '#66D6B4';
+export const SECONDARY_COLOR = '#d9d9d9';
 
 const themeOptions: ThemeOptions = {
   typography: {


### PR DESCRIPTION
closes #149 

## Summary

- 모임유형 버튼이 선택된 상태에서 회색 border를 가지는 이슈
- 선택된 경우에는 버튼 내부 색상으로 border가 지정되어 테두리가 보이지 않도록 수정

## Screenshot

<img width="351" alt="Screen Shot 2023-10-11 at 9 47 24 PM" src="https://github.com/Team-Panopticon/TBD-client/assets/32405358/1bc983d4-0ac4-4747-a7d4-629cddac385e">
