### PR TITLE
패스워드 4자리 입력시 자동 닫힘,패스워드창 위치

### DIFF
--- a/src/components/CenterContentModal.tsx
+++ b/src/components/CenterContentModal.tsx
@@ -8,7 +8,7 @@ export const Container = styled('div')({
 
 export const Content = styled('div')<{ width: number; height: number }>((props) => ({
   position: 'absolute',
-  top: '50%',
+  top: '40%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
 

--- a/src/components/MaskingInput.tsx
+++ b/src/components/MaskingInput.tsx
@@ -49,6 +49,9 @@ export function MaskingInput({ style, length, text, setText, size }: MaskingInpu
       return;
     }
     setText(e.target.value);
+    if (filledLength === length) {
+      return e.target.blur();
+    }
   };
   const inputRef = useRef<HTMLInputElement>(null);
   const handleClick = () => {


### PR DESCRIPTION
- 패스워드 4자리 입력시 자동 닫힘
- 모바일 키보드에 패스워드창이 가리는 문제 때문에 패스워드창 위치를 살짝 상단으로 이동

close #177 #199