### PR TITLE
index.html에 progress UI 추가, api interceptor 초기화에 설명 주석 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,10 +20,93 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      html,
+      body {
+        margin: 0;
+      }
+      .progress_container {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+
+        background-color: rgba(0, 0, 0, 0.5);
+      }
+
+      .progress_span {
+        width: 40px;
+        height: 40px;
+
+        display: inline-block;
+
+        -webkit-animation: rotate 1.4s linear infinite;
+        animation: rotate 1.4s linear infinite;
+      }
+
+      .progress_svg {
+        display: block;
+      }
+
+      .progress_circle {
+        display: block;
+        color: #66d6b4;
+
+        stroke: currentColor;
+        stroke-dasharray: 80px, 200px;
+        stroke-dashoffset: 0;
+        -webkit-animation: dash 1.4s ease-in-out infinite;
+        animation: dash 1.4s ease-in-out infinite;
+      }
+
+      @keyframes rotate {
+        0% {
+          transform: rotate(0deg);
+        }
+
+        100% {
+          transform: rotate(360deg);
+        }
+      }
+
+      @keyframes dash {
+        0% {
+          stroke-dasharray: 1px, 200px;
+          stroke-dashoffset: 0;
+        }
+
+        50% {
+          stroke-dasharray: 100px, 200px;
+          stroke-dashoffset: -15px;
+        }
+
+        100% {
+          stroke-dasharray: 100px, 200px;
+          stroke-dashoffset: -125px;
+        }
+      }
+    </style>
     <title>To Be Determined</title>
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <div class="progress_container">
+        <span class="progress_span">
+          <svg class="progress_svg" viewBox="22 22 44 44">
+            <circle
+              class="progress_circle"
+              cx="44"
+              cy="44"
+              r="20.2"
+              fill="none"
+              stroke-width="3.6"
+            ></circle>
+          </svg>
+        </span>
+      </div>
+    </div>
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.3.0/kakao.min.js"
       integrity="sha384-70k0rrouSYPWJt7q9rSTKpiTfX6USlMYjZUtr1Du+9o4cGvhPAWxngdtVZDdErlh"

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -84,6 +84,13 @@ export function App() {
     document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
   }, []);
 
+  /**
+   * bundle이 로딩되고 html에서 그린 progress가 제거된 뒤, 첫 API 콜 때 progress가 다시 그려져 깜빡이는 현상이 없도록 useEffect 내에서 처리
+   * (첫 API에 Progress가 적용되지 않음)
+   *
+   * - 첫 API에 Progress가 그려질 경우 >> html에 적용된 progress -> 흰 화면 -> 첫 API에 의한 progress -> 페이지
+   * - 첫 API에 Progress가 안그려질 경우 >> html에 적용된 progress -> 흰 화면 -> 흰 화면 -> 페이지
+   */
   useEffect(() => {
     initializeProgressInterceptor(setShowProgress);
   }, [setShowProgress]);


### PR DESCRIPTION
closes #198 


- index.html에 progress UI 추가

  - material ui의 progress 스타일을 그대로 적용

  - react가 그리는 root div에 progress를 그려 root div에 컴포넌트가 그려지며 자동으로 삭제

- api interceptor 초기화에 설명 주석 추가