### PR TITLE
설정 버튼 색상을 black으로 지정

### DIFF
--- a/src/templates/MeetingView/Dropdown/styled.tsx
+++ b/src/templates/MeetingView/Dropdown/styled.tsx
@@ -6,10 +6,11 @@ export const DropdownContainer = styled('div')({
 });
 
 export const ImageWrapper = styled('button')({
+  color: '#000000',
   background: 'none',
   border: '0',
   display: 'flex',
-  width: '25px',
+  width: '24px',
   cursor: 'pointer',
   img: {
     width: '100%',


### PR DESCRIPTION
closes #238 

- Safari에서 버튼 기본색상이 파란색으로 변하는 것 방지