### PR TITLE
결과페이지 축하합니다 문구 중앙정렬 추가

### DIFF
--- a/src/pages/MeetingResult.tsx
+++ b/src/pages/MeetingResult.tsx
@@ -51,7 +51,7 @@ export function MeetingResult() {
             <HeaderContainer>
               <FlexVertical flex={1} alignItems={'center'} gap={1}>
                 <FlexVertical flex={1} gap={1}>
-                  <Typography variant="h5" fontWeight={700}>
+                  <Typography variant="h5" fontWeight={700} alignSelf={'center'}>
                     축하합니다!
                   </Typography>
                   <FlexVertical alignItems={'center'}>


### PR DESCRIPTION
closes #236 

- meeting name이 길어질 경우 상위 요소가 길어지며 축하합니다 문구가 왼쪽으로 치우치는 이슈

  축하합니다 문구가 항상 중앙에 정렬되게 수정

![image](https://github.com/Team-Panopticon/TBD-client/assets/55068119/32a6d492-ba25-489e-8280-d4dbb60d7403)
![image](https://github.com/Team-Panopticon/TBD-client/assets/55068119/d90f5dd4-cf49-4361-aefd-0b7497f14040)
