### PR TITLE
하단 버튼 UI 변경 (여백 추가 & 라운드 처리)

### DIFF
--- a/src/components/pageLayout.tsx
+++ b/src/components/pageLayout.tsx
@@ -59,6 +59,7 @@ export const Footer = styled('footer')({
   position: 'fixed',
   bottom: 0,
   width: '100%',
-  height: '56px',
+  height: '64px',
   flexShrink: 0,
+  padding: '8px 32px',
 });

--- a/src/components/styled.tsx
+++ b/src/components/styled.tsx
@@ -2,10 +2,12 @@ import { Box, ButtonGroup, styled } from '@mui/material';
 
 export const FullHeightButtonGroup = styled(ButtonGroup)`
   height: 100%;
-
+  display: flex;
+  column-gap: 16px;
   & .MuiButton-root {
     height: 100%;
-    border-radius: 0;
+    /** ButtonGroup 컴포넌트의 top-right / bottom-right radius 0 설정을 무시하기 위하여 important 추가 */
+    border-radius: 8px !important;
     font-weight: 500;
   }
   /* ButtonGroup 컴포넌트의 borderRight 기본 스타일을 diable 하기 위하여 스타일 추가 */

--- a/src/templates/MeetingEdit/CreatePasswordModal.tsx
+++ b/src/templates/MeetingEdit/CreatePasswordModal.tsx
@@ -31,7 +31,7 @@ export function CreatePasswordModal({
   const isPasswordValid = password !== undefined && validatePassword(password);
 
   return (
-    <CenterContentModal open={show} width={320} height={230}>
+    <CenterContentModal open={show} width={320} height={208}>
       <PasswordInput>
         <Typography variant="subtitle1" fontWeight={300}>
           비밀번호를 설정할 수 있어요.
@@ -44,16 +44,10 @@ export function CreatePasswordModal({
           모임을 수정하거나 확정할 때 사용해요
         </Typography>
         <MaskingInputContainer>
-          <MaskingInput
-            length={4}
-            text={password ?? ''}
-            setText={onChange}
-            size={30}
-            style={{ paddingTop: 10 }}
-          />
+          <MaskingInput length={4} text={password ?? ''} setText={onChange} size={28} />
         </MaskingInputContainer>
       </PasswordInput>
-      <div style={{ height: 50 }}>
+      <div style={{ height: 64, padding: '12px 24px' }}>
         <FullHeightButtonGroup
           fullWidth
           disableElevation

--- a/src/templates/MeetingEdit/styled.tsx
+++ b/src/templates/MeetingEdit/styled.tsx
@@ -63,7 +63,7 @@ export const StepBoxContainer = styled('div')({
 });
 
 export const PasswordInput = styled('div')({
-  padding: '25px 35px',
+  padding: '25px 35px 0',
 
   display: 'flex',
   flexDirection: 'column',

--- a/src/templates/MeetingView/InputPasswordModal.tsx
+++ b/src/templates/MeetingView/InputPasswordModal.tsx
@@ -77,7 +77,7 @@ export function InputPasswordModal({ meetingId, show, onConfirm, onCancel }: Pro
             text={password}
             setText={handlePasswordChange}
             size={30}
-            style={{ paddingTop: 10 }}
+            style={{ paddingBottom: 10 }}
           />
         </MaskingInputContainer>
       </PasswordInput>


### PR DESCRIPTION
- Button Group에 좌우 / 하단 여백 추가

  pageLayout Footer에 하단 여백 설정

- Button Group 버튼 사이 여백백 추가 및 Round 처리 추가

---

<img src="https://github.com/Team-Panopticon/TBD-client/assets/55068119/353b4baf-b62c-438b-88d1-4e07a732e281">
<img src="https://github.com/Team-Panopticon/TBD-client/assets/55068119/2062c24d-725e-480a-8af0-64907e1fbef3">

<img src="https://github.com/Team-Panopticon/TBD-client/assets/55068119/7b6eb6af-ad89-4f62-bce6-49663a5199aa">
<img src="https://github.com/Team-Panopticon/TBD-client/assets/55068119/d57a0bb5-1cd6-4475-b4f4-45fbd40ef00c">
