### PR TITLE
fix: react-query에서 query가  새로 불러와질 때 로딩이 뜨지 않는 버그 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,22 +28,7 @@
     ></script>
   </head>
   <body>
-    <div id="root">
-      <div class="progress_container">
-        <span class="progress_span">
-          <svg class="progress_svg" viewBox="22 22 44 44">
-            <circle
-              class="progress_circle"
-              cx="44"
-              cy="44"
-              r="20.2"
-              fill="none"
-              stroke-width="3.6"
-            ></circle>
-          </svg>
-        </span>
-      </div>
-    </div>
+    <div id="root"></div>
     <script type="module" src="/src/main.tsx" defer></script>
   </body>
 </html>

--- a/src/hooks/useMeetingData.ts
+++ b/src/hooks/useMeetingData.ts
@@ -4,11 +4,11 @@ import { getMeeting } from '../apis/meetings';
 import { getVotings } from '../apis/votes';
 
 export const useMeetingData = (meetingId: string) => {
-  const { data: meeting, isLoading: isMeetingLoading } = useQuery({
+  const { data: meeting, isFetching: isMeetingFetching } = useQuery({
     queryKey: ['meeting', meetingId],
     queryFn: () => getMeeting(meetingId),
   });
-  const { data: votings, isLoading: isVotingsLoading } = useQuery({
+  const { data: votings, isFetching: isVotingsFetching } = useQuery({
     queryKey: ['votings', meetingId],
     queryFn: () => getVotings(meetingId),
   });
@@ -18,6 +18,6 @@ export const useMeetingData = (meetingId: string) => {
       meeting,
       votings,
     },
-    isLoading: isMeetingLoading && isVotingsLoading,
+    isFetching: isMeetingFetching && isVotingsFetching,
   };
 };

--- a/src/pages/MeetingConfirm/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm/MeetingConfirm.tsx
@@ -32,7 +32,7 @@ function MeetingConfirm() {
   const navigate = useNavigate();
 
   const { meetingId } = useParams<keyof MeetingConfirmPathParams>() as MeetingConfirmPathParams;
-  const { data, isLoading } = useMeetingData(meetingId);
+  const { data, isFetching } = useMeetingData(meetingId);
 
   const setVotings = useSetRecoilState<Voting[]>(votingsState);
   const {
@@ -93,7 +93,7 @@ function MeetingConfirm() {
     comfirmMeetingMutation.mutate({ meetingId, slot: selectedSlot });
   };
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 

--- a/src/pages/MeetingResult/MeetingResult.tsx
+++ b/src/pages/MeetingResult/MeetingResult.tsx
@@ -23,7 +23,7 @@ function MeetingResult() {
   const { openShare, setTarget } = useShare();
   const {
     data: { meeting, votings },
-    isLoading,
+    isFetching,
   } = useMeetingData(meetingId || '');
 
   useEffect(() => {
@@ -39,11 +39,7 @@ function MeetingResult() {
   const meetingDate = meeting?.confirmedDateType?.date;
   const meetingMeal = meeting?.confirmedDateType?.meal;
 
-  if (isLoading) {
-    return <Loading />;
-  }
-
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 

--- a/src/pages/MeetingResult/MeetingResult.tsx
+++ b/src/pages/MeetingResult/MeetingResult.tsx
@@ -43,6 +43,10 @@ function MeetingResult() {
     return <Loading />;
   }
 
+  if (isLoading) {
+    return <Loading />;
+  }
+
   return (
     <Page>
       <Contents>

--- a/src/pages/MeetingView/MeetingView.tsx
+++ b/src/pages/MeetingView/MeetingView.tsx
@@ -50,7 +50,7 @@ function MeetingView() {
   const { openShare, setTarget } = useShare();
   const { show, hide } = useProgress();
 
-  const { data, isLoading } = useMeetingData(meetingId);
+  const { data, isFetching } = useMeetingData(meetingId);
 
   const { handleClickUserList, handleClickVoteTable, userList, voteTableDataList } = useMeetingView(
     data.meeting,
@@ -120,7 +120,7 @@ function MeetingView() {
     setShowPasswordModal(false);
   };
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 

--- a/src/pages/MeetingVote/MeetingVote.tsx
+++ b/src/pages/MeetingVote/MeetingVote.tsx
@@ -48,7 +48,7 @@ function MeetingVote() {
 
   const [showUsernameModal, setShowUsernameModal] = useState<boolean>(false);
 
-  const { data, isLoading } = useMeetingData(meetingId);
+  const { data, isFetching } = useMeetingData(meetingId);
 
   const navigate = useNavigate();
   const { show, hide } = useProgress();
@@ -177,7 +177,7 @@ function MeetingVote() {
     });
   };
 
-  if (isLoading) {
+  if (isFetching) {
     return <Loading />;
   }
 


### PR DESCRIPTION
## 주요 변경 사항

- isLoading 대신에 isFetching을 사용하도록 수정했어요.
  - 근데 조금 늦게 렌더링되어서 보이게 하는 것은 아직 어떻게 수정해야할지 잘 모르겠네요 ㅠㅠ 좋은 방법 떠오르시는 분은 알려주시면 감사하겠습니다.

close #257