### PR TITLE
feat: MeetingConfirm 페이지를 header, contents, footer로 분리

### DIFF
--- a/src/hooks/MeetingConfirm/useMeetingConfirmContents.ts
+++ b/src/hooks/MeetingConfirm/useMeetingConfirmContents.ts
@@ -1,0 +1,43 @@
+import { Dayjs } from 'dayjs';
+
+import { VotingSlot } from '../../apis/votes';
+import { VoteTableVoting } from '../../components/VoteTable/VoteTable';
+import { useMeeting } from '../useMeeting';
+import { useMeetingView } from '../useMeetingView';
+import { isSameSlot } from '../useMeetingVote';
+
+export const useMeetingConfirmContents = ({
+  selectedSlot,
+  setSelectedSlot,
+}: {
+  selectedSlot?: VotingSlot;
+  setSelectedSlot: React.Dispatch<React.SetStateAction<VotingSlot | undefined>>;
+}) => {
+  const { meeting } = useMeeting();
+  const {
+    handleClickVoteTable: handleVoteTableClickHightlight,
+    userList,
+    voteTableDataList,
+  } = useMeetingView(meeting);
+
+  const handleClickVoteTable = (
+    date: Dayjs,
+    checked: boolean,
+    target: VoteTableVoting,
+    slot: VotingSlot,
+  ) => {
+    if (selectedSlot && isSameSlot(selectedSlot, slot)) {
+      setSelectedSlot(undefined);
+    } else {
+      setSelectedSlot(slot);
+    }
+    handleVoteTableClickHightlight(date, checked, target, slot);
+  };
+
+  return {
+    meeting,
+    userList,
+    voteTableDataList,
+    handleClickVoteTable,
+  };
+};

--- a/src/hooks/MeetingConfirm/useMeetingConfirmContents.ts
+++ b/src/hooks/MeetingConfirm/useMeetingConfirmContents.ts
@@ -1,10 +1,14 @@
 import { Dayjs } from 'dayjs';
+import { useEffect } from 'react';
+import { useSetRecoilState } from 'recoil';
 
-import { VotingSlot } from '../../apis/votes';
+import { Voting, VotingSlot } from '../../apis/votes';
 import { VoteTableVoting } from '../../components/VoteTable/VoteTable';
+import { votingsState } from '../../stores/voting';
 import { useMeeting } from '../useMeeting';
 import { useMeetingView } from '../useMeetingView';
 import { isSameSlot } from '../useMeetingVote';
+import { useVotings } from '../useVotings';
 
 export const useMeetingConfirmContents = ({
   selectedSlot,
@@ -14,11 +18,19 @@ export const useMeetingConfirmContents = ({
   setSelectedSlot: React.Dispatch<React.SetStateAction<VotingSlot | undefined>>;
 }) => {
   const { meeting } = useMeeting();
+  const { votings } = useVotings();
   const {
     handleClickVoteTable: handleVoteTableClickHightlight,
     userList,
     voteTableDataList,
   } = useMeetingView(meeting);
+  const setVotings = useSetRecoilState<Voting[]>(votingsState);
+
+  useEffect(() => {
+    if (votings) {
+      setVotings(votings);
+    }
+  }, [setVotings, votings]);
 
   const handleClickVoteTable = (
     date: Dayjs,

--- a/src/hooks/MeetingConfirm/useMeetingConfirmFooter.ts
+++ b/src/hooks/MeetingConfirm/useMeetingConfirmFooter.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { confirmMeeting } from '../../apis/meetings';
+import { VotingSlot } from '../../apis/votes';
+import { MeetingStatus } from '../../constants/meeting';
+import { MEETING_QUERY_KEY, useMeeting } from '../useMeeting';
+import { useProgress } from '../useProgress';
+
+export const useMeetingConfirmFooter = (selectedSlot?: VotingSlot) => {
+  const { meeting, meetingId } = useMeeting();
+  const navigate = useNavigate();
+  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
+  const { show, hide } = useProgress();
+  const queryClient = useQueryClient();
+  const comfirmMeetingMutation = useMutation<void, Error, { meetingId: string; slot: VotingSlot }>({
+    mutationFn: ({ meetingId, slot }) => confirmMeeting(meetingId, slot),
+    onMutate: () => show(),
+    onSuccess: () => {
+      queryClient.setQueryData([MEETING_QUERY_KEY, meetingId], {
+        ...meeting,
+        status: MeetingStatus.done,
+      });
+      navigate(`/meetings/${meetingId}/result`);
+    },
+    onError: (error) => {
+      const errorMessage =
+        error instanceof Error ? error.message : '정상적으로 처리되지 못했습니다.';
+      alert(errorMessage);
+      setShowConfirmModal(false);
+    },
+    onSettled: () => hide(),
+  });
+
+  const handleConfirm = () => {
+    if (!selectedSlot) {
+      return;
+    }
+
+    show();
+    comfirmMeetingMutation.mutate({ meetingId, slot: selectedSlot });
+  };
+
+  return {
+    meetingId,
+    showConfirmModal,
+    navigate,
+    handleConfirm,
+    setShowConfirmModal,
+  };
+};

--- a/src/pages/MeetingConfirm/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm/MeetingConfirm.tsx
@@ -1,29 +1,20 @@
-import { useEffect, useState } from 'react';
-import { useSetRecoilState } from 'recoil';
+import { useState } from 'react';
 
-import { Voting, VotingSlot } from '../../apis/votes';
+import { VotingSlot } from '../../apis/votes';
 import { Loading } from '../../components/Loading';
 import { Page } from '../../components/pageLayout';
 import { useMeeting } from '../../hooks/useMeeting';
 import { useVotings } from '../../hooks/useVotings';
-import { votingsState } from '../../stores/voting';
 import MeetingConfirmContents from '../../templates/MeetingConfirm/MeetingConfirmContents';
 import MeetingConfirmFooter from '../../templates/MeetingConfirm/MeetingConfirmFooter';
 import MeetingConfirmHeader from '../../templates/MeetingConfirm/MeetingConfirmHeader';
 
 function MeetingConfirm() {
   const { isFetching: isMeetingFetching } = useMeeting();
-  const { votings, isFetching: isVotingsFetcing } = useVotings();
+  const { isFetching: isVotingsFetcing } = useVotings();
   const isFetching = isMeetingFetching && isVotingsFetcing;
 
-  const setVotings = useSetRecoilState<Voting[]>(votingsState);
   const [selectedSlot, setSelectedSlot] = useState<VotingSlot>();
-
-  useEffect(() => {
-    if (votings) {
-      setVotings(votings);
-    }
-  }, [setVotings, votings]);
 
   if (isFetching) {
     return <Loading />;

--- a/src/pages/MeetingConfirm/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm/MeetingConfirm.tsx
@@ -1,69 +1,29 @@
-import Button from '@mui/material/Button';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
 
-import { confirmMeeting } from '../../apis/meetings';
 import { Voting, VotingSlot } from '../../apis/votes';
 import { Loading } from '../../components/Loading';
-import { Footer, Page } from '../../components/pageLayout';
-import { FullHeightButtonGroup } from '../../components/styled';
-import { MeetingStatus } from '../../constants/meeting';
-import { MEETING_QUERY_KEY, useMeeting } from '../../hooks/useMeeting';
-import { useProgress } from '../../hooks/useProgress';
+import { Page } from '../../components/pageLayout';
+import { useMeeting } from '../../hooks/useMeeting';
 import { useVotings } from '../../hooks/useVotings';
 import { votingsState } from '../../stores/voting';
 import MeetingConfirmContents from '../../templates/MeetingConfirm/MeetingConfirmContents';
+import MeetingConfirmFooter from '../../templates/MeetingConfirm/MeetingConfirmFooter';
 import MeetingConfirmHeader from '../../templates/MeetingConfirm/MeetingConfirmHeader';
-import { CheckConfirmModal } from '../../templates/MeetingView/CheckConfirmModal';
 
 function MeetingConfirm() {
-  const navigate = useNavigate();
-
-  const { meeting, meetingId, isFetching: isMeetingFetching } = useMeeting();
+  const { isFetching: isMeetingFetching } = useMeeting();
   const { votings, isFetching: isVotingsFetcing } = useVotings();
   const isFetching = isMeetingFetching && isVotingsFetcing;
 
   const setVotings = useSetRecoilState<Voting[]>(votingsState);
   const [selectedSlot, setSelectedSlot] = useState<VotingSlot>();
 
-  const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
-  const { show, hide } = useProgress();
-  const queryClient = useQueryClient();
-  const comfirmMeetingMutation = useMutation<void, Error, { meetingId: string; slot: VotingSlot }>({
-    mutationFn: ({ meetingId, slot }) => confirmMeeting(meetingId, slot),
-    onMutate: () => show(),
-    onSuccess: () => {
-      queryClient.setQueryData([MEETING_QUERY_KEY, meetingId], {
-        ...meeting,
-        status: MeetingStatus.done,
-      });
-      navigate(`/meetings/${meetingId}/result`);
-    },
-    onError: (error) => {
-      const errorMessage =
-        error instanceof Error ? error.message : '정상적으로 처리되지 못했습니다.';
-      alert(errorMessage);
-      setShowConfirmModal(false);
-    },
-    onSettled: () => hide(),
-  });
-
   useEffect(() => {
     if (votings) {
       setVotings(votings);
     }
   }, [setVotings, votings]);
-
-  const handleConfirm = () => {
-    if (!selectedSlot) {
-      return;
-    }
-
-    show();
-    comfirmMeetingMutation.mutate({ meetingId, slot: selectedSlot });
-  };
 
   if (isFetching) {
     return <Loading />;
@@ -73,40 +33,7 @@ function MeetingConfirm() {
     <Page>
       <MeetingConfirmHeader />
       <MeetingConfirmContents selectedSlot={selectedSlot} setSelectedSlot={setSelectedSlot} />
-      <Footer>
-        <FullHeightButtonGroup
-          fullWidth
-          disableElevation
-          variant="contained"
-          aria-label="Disabled elevation buttons"
-        >
-          <Button
-            color="secondary"
-            onClick={() => {
-              navigate(`/meetings/${meetingId}`);
-            }}
-          >
-            취소
-          </Button>
-          <Button
-            color="primary"
-            disabled={!selectedSlot}
-            onClick={() => {
-              setShowConfirmModal(true);
-            }}
-          >
-            모임 확정
-          </Button>
-        </FullHeightButtonGroup>
-      </Footer>
-      <CheckConfirmModal
-        show={showConfirmModal}
-        slot={selectedSlot}
-        onConfirm={handleConfirm}
-        onCancel={() => {
-          setShowConfirmModal(false);
-        }}
-      />
+      <MeetingConfirmFooter selectedSlot={selectedSlot} />
     </Page>
   );
 }

--- a/src/pages/MeetingConfirm/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm/MeetingConfirm.tsx
@@ -1,7 +1,4 @@
-import EventAvailableIcon from '@mui/icons-material/EventAvailable';
-import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
@@ -11,8 +8,8 @@ import { useSetRecoilState } from 'recoil';
 import { confirmMeeting } from '../../apis/meetings';
 import { Voting, VotingSlot } from '../../apis/votes';
 import { Loading } from '../../components/Loading';
-import { Contents, Footer, Header, HeaderContainer, Page } from '../../components/pageLayout';
-import { FlexVertical, FullHeightButtonGroup } from '../../components/styled';
+import { Contents, Footer, Page } from '../../components/pageLayout';
+import { FullHeightButtonGroup } from '../../components/styled';
 import { UserList } from '../../components/UserList/UserList';
 import { VoteTable, VoteTableVoting } from '../../components/VoteTable/VoteTable';
 import { MeetingStatus, MeetingType } from '../../constants/meeting';
@@ -22,6 +19,7 @@ import { isSameSlot } from '../../hooks/useMeetingVote';
 import { useProgress } from '../../hooks/useProgress';
 import { useVotings } from '../../hooks/useVotings';
 import { votingsState } from '../../stores/voting';
+import MeetingConfirmHeader from '../../templates/MeetingConfirm/MeetingConfirmHeader';
 import { CheckConfirmModal } from '../../templates/MeetingView/CheckConfirmModal';
 import { VoteTableWrapper } from '../../templates/MeetingView/styled';
 
@@ -97,31 +95,7 @@ function MeetingConfirm() {
 
   return (
     <Page>
-      <Header>
-        <HeaderContainer>
-          <FlexVertical flex={1} alignItems={'center'} gap={1}>
-            <FlexVertical flex={1} gap={1} width={'100%'}>
-              <Box
-                display={'flex'}
-                flexDirection={'row'}
-                justifyContent={'center'}
-                alignItems={'center'}
-                gap={1}
-              >
-                <Typography variant="h5" fontWeight={700}>
-                  {meeting?.name}
-                </Typography>
-              </Box>
-              <FlexVertical alignItems={'center'}>
-                <EventAvailableIcon sx={{ fontSize: 110 }} />
-              </FlexVertical>
-              <Typography variant="h6" fontWeight={400} align="center">
-                모임시간을 골라서 확정해주세요
-              </Typography>
-            </FlexVertical>
-          </FlexVertical>
-        </HeaderContainer>
-      </Header>
+      <MeetingConfirmHeader />
       <Contents>
         <UserList users={userList} isSticky>
           <UserList.Title color="primary">투표 현황</UserList.Title>

--- a/src/pages/MeetingConfirm/MeetingConfirm.tsx
+++ b/src/pages/MeetingConfirm/MeetingConfirm.tsx
@@ -1,6 +1,5 @@
 import Button from '@mui/material/Button';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Dayjs } from 'dayjs';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useSetRecoilState } from 'recoil';
@@ -8,20 +7,16 @@ import { useSetRecoilState } from 'recoil';
 import { confirmMeeting } from '../../apis/meetings';
 import { Voting, VotingSlot } from '../../apis/votes';
 import { Loading } from '../../components/Loading';
-import { Contents, Footer, Page } from '../../components/pageLayout';
+import { Footer, Page } from '../../components/pageLayout';
 import { FullHeightButtonGroup } from '../../components/styled';
-import { UserList } from '../../components/UserList/UserList';
-import { VoteTable, VoteTableVoting } from '../../components/VoteTable/VoteTable';
-import { MeetingStatus, MeetingType } from '../../constants/meeting';
+import { MeetingStatus } from '../../constants/meeting';
 import { MEETING_QUERY_KEY, useMeeting } from '../../hooks/useMeeting';
-import { useMeetingView } from '../../hooks/useMeetingView';
-import { isSameSlot } from '../../hooks/useMeetingVote';
 import { useProgress } from '../../hooks/useProgress';
 import { useVotings } from '../../hooks/useVotings';
 import { votingsState } from '../../stores/voting';
+import MeetingConfirmContents from '../../templates/MeetingConfirm/MeetingConfirmContents';
 import MeetingConfirmHeader from '../../templates/MeetingConfirm/MeetingConfirmHeader';
 import { CheckConfirmModal } from '../../templates/MeetingView/CheckConfirmModal';
-import { VoteTableWrapper } from '../../templates/MeetingView/styled';
 
 function MeetingConfirm() {
   const navigate = useNavigate();
@@ -31,13 +26,8 @@ function MeetingConfirm() {
   const isFetching = isMeetingFetching && isVotingsFetcing;
 
   const setVotings = useSetRecoilState<Voting[]>(votingsState);
-  const {
-    handleClickVoteTable: handleVoteTableClickHightlight,
-    userList,
-    voteTableDataList,
-  } = useMeetingView(meeting);
-
   const [selectedSlot, setSelectedSlot] = useState<VotingSlot>();
+
   const [showConfirmModal, setShowConfirmModal] = useState<boolean>(false);
   const { show, hide } = useProgress();
   const queryClient = useQueryClient();
@@ -66,20 +56,6 @@ function MeetingConfirm() {
     }
   }, [setVotings, votings]);
 
-  const handleClickVoteTable = (
-    date: Dayjs,
-    checked: boolean,
-    target: VoteTableVoting,
-    slot: VotingSlot,
-  ) => {
-    if (selectedSlot && isSameSlot(selectedSlot, slot)) {
-      setSelectedSlot(undefined);
-    } else {
-      setSelectedSlot(slot);
-    }
-    handleVoteTableClickHightlight(date, checked, target, slot);
-  };
-
   const handleConfirm = () => {
     if (!selectedSlot) {
       return;
@@ -96,19 +72,7 @@ function MeetingConfirm() {
   return (
     <Page>
       <MeetingConfirmHeader />
-      <Contents>
-        <UserList users={userList} isSticky>
-          <UserList.Title color="primary">투표 현황</UserList.Title>
-        </UserList>
-
-        <VoteTableWrapper>
-          <VoteTable
-            onSlotClick={handleClickVoteTable}
-            data={voteTableDataList}
-            headers={meeting?.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
-          />
-        </VoteTableWrapper>
-      </Contents>
+      <MeetingConfirmContents selectedSlot={selectedSlot} setSelectedSlot={setSelectedSlot} />
       <Footer>
         <FullHeightButtonGroup
           fullWidth

--- a/src/templates/MeetingConfirm/MeetingConfirmContents/index.tsx
+++ b/src/templates/MeetingConfirm/MeetingConfirmContents/index.tsx
@@ -1,0 +1,34 @@
+import { VotingSlot } from '../../../apis/votes';
+import { Contents } from '../../../components/pageLayout';
+import { UserList } from '../../../components/UserList/UserList';
+import { VoteTable } from '../../../components/VoteTable/VoteTable';
+import { MeetingType } from '../../../constants/meeting';
+import { useMeetingConfirmContents } from '../../../hooks/MeetingConfirm/useMeetingConfirmContents';
+import { VoteTableWrapper } from '../../MeetingView/styled';
+
+interface Props {
+  selectedSlot?: VotingSlot;
+  setSelectedSlot: React.Dispatch<React.SetStateAction<VotingSlot | undefined>>;
+}
+
+const MeetingConfirmContents = (props: Props) => {
+  const { userList, handleClickVoteTable, voteTableDataList, meeting } =
+    useMeetingConfirmContents(props);
+  return (
+    <Contents>
+      <UserList users={userList} isSticky>
+        <UserList.Title color="primary">투표 현황</UserList.Title>
+      </UserList>
+
+      <VoteTableWrapper>
+        <VoteTable
+          onSlotClick={handleClickVoteTable}
+          data={voteTableDataList}
+          headers={meeting?.type === MeetingType.date ? ['투표 현황'] : ['점심', '저녁']}
+        />
+      </VoteTableWrapper>
+    </Contents>
+  );
+};
+
+export default MeetingConfirmContents;

--- a/src/templates/MeetingConfirm/MeetingConfirmFooter/index.tsx
+++ b/src/templates/MeetingConfirm/MeetingConfirmFooter/index.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@mui/material';
+
+import { VotingSlot } from '../../../apis/votes';
+import { Footer } from '../../../components/pageLayout';
+import { FullHeightButtonGroup } from '../../../components/styled';
+import { useMeetingConfirmFooter } from '../../../hooks/MeetingConfirm/useMeetingConfirmFooter';
+import { CheckConfirmModal } from '../../MeetingView/CheckConfirmModal';
+
+interface Props {
+  selectedSlot?: VotingSlot;
+}
+
+const MeetingConfirmFooter = ({ selectedSlot }: Props) => {
+  const { meetingId, showConfirmModal, navigate, handleConfirm, setShowConfirmModal } =
+    useMeetingConfirmFooter(selectedSlot);
+
+  return (
+    <>
+      <Footer>
+        <FullHeightButtonGroup
+          fullWidth
+          disableElevation
+          variant="contained"
+          aria-label="Disabled elevation buttons"
+        >
+          <Button
+            color="secondary"
+            onClick={() => {
+              navigate(`/meetings/${meetingId}`);
+            }}
+          >
+            취소
+          </Button>
+          <Button
+            color="primary"
+            disabled={!selectedSlot}
+            onClick={() => {
+              setShowConfirmModal(true);
+            }}
+          >
+            모임 확정
+          </Button>
+        </FullHeightButtonGroup>
+      </Footer>
+      <CheckConfirmModal
+        show={showConfirmModal}
+        slot={selectedSlot}
+        onConfirm={handleConfirm}
+        onCancel={() => {
+          setShowConfirmModal(false);
+        }}
+      />
+    </>
+  );
+};
+
+export default MeetingConfirmFooter;

--- a/src/templates/MeetingConfirm/MeetingConfirmHeader/index.tsx
+++ b/src/templates/MeetingConfirm/MeetingConfirmHeader/index.tsx
@@ -1,0 +1,41 @@
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+import { Header, HeaderContainer } from '../../../components/pageLayout';
+import { FlexVertical } from '../../../components/styled';
+import { useMeeting } from '../../../hooks/useMeeting';
+
+const MeetingConfirmHeader = () => {
+  const { meeting } = useMeeting();
+
+  return (
+    <Header>
+      <HeaderContainer>
+        <FlexVertical flex={1} alignItems={'center'} gap={1}>
+          <FlexVertical flex={1} gap={1} width={'100%'}>
+            <Box
+              display={'flex'}
+              flexDirection={'row'}
+              justifyContent={'center'}
+              alignItems={'center'}
+              gap={1}
+            >
+              <Typography variant="h5" fontWeight={700}>
+                {meeting?.name}
+              </Typography>
+            </Box>
+            <FlexVertical alignItems={'center'}>
+              <EventAvailableIcon sx={{ fontSize: 110 }} />
+            </FlexVertical>
+            <Typography variant="h6" fontWeight={400} align="center">
+              모임시간을 골라서 확정해주세요
+            </Typography>
+          </FlexVertical>
+        </FlexVertical>
+      </HeaderContainer>
+    </Header>
+  );
+};
+
+export default MeetingConfirmHeader;


### PR DESCRIPTION
## 주요 변경 내용

- MeetingConfirm 페이지를 header, contents, footer로 분리했어요.
- useMeetingView를 사용하는 부분이 있는데 해당 부분은 나중에 MeetingView mr이 닫히면서 수정하겠습니다!