### PR TITLE
소수점으로 scroll이 남을경우 맨 아래이지만 스크롤 버튼이 사라지지 않는 이슈 해결

### DIFF
--- a/src/constants/meeting.ts
+++ b/src/constants/meeting.ts
@@ -19,3 +19,4 @@ export enum MeetingAdminAccess {
 }
 
 export const INPUT_PASSWORD_FINISH_EVENT = 'inputPasswordFinish';
+export const SCROLL_DOWN_BUTTON_MARGIN = 4;

--- a/src/pages/MeetingView/MeetingView.tsx
+++ b/src/pages/MeetingView/MeetingView.tsx
@@ -3,6 +3,7 @@ import { useResizeDetector } from 'react-resize-detector';
 
 import { ScrollDownFloatingButton } from '../../components/buttons/ScrollDownFloatingButton';
 import { Page } from '../../components/pageLayout';
+import { SCROLL_DOWN_BUTTON_MARGIN } from '../../constants/meeting';
 import MeetingViewContents from '../../templates/MeetingView/MeetingViewContents';
 import MeetingViewFooter from '../../templates/MeetingView/MeetingViewFooter';
 import MeetingViewHeader from '../../templates/MeetingView/MeetingViewHeader';
@@ -20,14 +21,14 @@ function MeetingView() {
       }
       const { scrollTop, scrollHeight, clientHeight } = pageElementRef.current;
       const remainingScroll = scrollHeight - scrollTop - clientHeight;
-      setHasMoreBottomScroll(remainingScroll > 4);
+      setHasMoreBottomScroll(remainingScroll > SCROLL_DOWN_BUTTON_MARGIN);
     },
   });
 
   const handlePageScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
     const remainingScroll = scrollHeight - scrollTop - clientHeight;
-    setHasMoreBottomScroll(remainingScroll > 4);
+    setHasMoreBottomScroll(remainingScroll > SCROLL_DOWN_BUTTON_MARGIN);
   };
 
   const handleScollDownButtonClick = () => {

--- a/src/pages/MeetingView/MeetingView.tsx
+++ b/src/pages/MeetingView/MeetingView.tsx
@@ -19,13 +19,15 @@ function MeetingView() {
         return;
       }
       const { scrollTop, scrollHeight, clientHeight } = pageElementRef.current;
-      setHasMoreBottomScroll(scrollTop + clientHeight < scrollHeight);
+      const remainingScroll = scrollHeight - scrollTop - clientHeight;
+      setHasMoreBottomScroll(remainingScroll > 4);
     },
   });
 
   const handlePageScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
-    setHasMoreBottomScroll(scrollTop + clientHeight < scrollHeight);
+    const remainingScroll = scrollHeight - scrollTop - clientHeight;
+    setHasMoreBottomScroll(remainingScroll > 4);
   };
 
   const handleScollDownButtonClick = () => {

--- a/src/pages/MeetingVote/MeetingVote.tsx
+++ b/src/pages/MeetingVote/MeetingVote.tsx
@@ -5,6 +5,7 @@ import { useRecoilValue } from 'recoil';
 
 import { ScrollDownFloatingButton } from '../../components/buttons/ScrollDownFloatingButton';
 import { Page } from '../../components/pageLayout';
+import { SCROLL_DOWN_BUTTON_MARGIN } from '../../constants/meeting';
 import { useMeeting } from '../../hooks/useMeeting';
 import { currentUserStateFamily } from '../../stores/currentUser';
 import MeetingVoteContents from '../../templates/MeetingVote/MeetingVoteContents';
@@ -38,14 +39,14 @@ function MeetingVote() {
       }
       const { scrollTop, scrollHeight, clientHeight } = pageElementRef.current;
       const remainingScroll = scrollHeight - scrollTop - clientHeight;
-      setHasMoreBottomScroll(remainingScroll > 4);
+      setHasMoreBottomScroll(remainingScroll > SCROLL_DOWN_BUTTON_MARGIN);
     },
   });
 
   const handlePageScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
     const remainingScroll = scrollHeight - scrollTop - clientHeight;
-    setHasMoreBottomScroll(remainingScroll > 4);
+    setHasMoreBottomScroll(remainingScroll > SCROLL_DOWN_BUTTON_MARGIN);
   };
 
   const handleScollDownButtonClick = () => {

--- a/src/pages/MeetingVote/MeetingVote.tsx
+++ b/src/pages/MeetingVote/MeetingVote.tsx
@@ -37,13 +37,15 @@ function MeetingVote() {
         return;
       }
       const { scrollTop, scrollHeight, clientHeight } = pageElementRef.current;
-      setHasMoreBottomScroll(scrollTop + clientHeight < scrollHeight);
+      const remainingScroll = scrollHeight - scrollTop - clientHeight;
+      setHasMoreBottomScroll(remainingScroll > 4);
     },
   });
 
   const handlePageScroll = (event: UIEvent<HTMLDivElement>) => {
     const { scrollTop, scrollHeight, clientHeight } = event.currentTarget;
-    setHasMoreBottomScroll(scrollTop + clientHeight < scrollHeight);
+    const remainingScroll = scrollHeight - scrollTop - clientHeight;
+    setHasMoreBottomScroll(remainingScroll > 4);
   };
 
   const handleScollDownButtonClick = () => {


### PR DESCRIPTION
## Screenshot

### 맨 아래로 스크롤했지만 버튼이 없어지지 않는 영상

https://github.com/Team-Panopticon/TBD-client/assets/32405358/684a6567-9f13-4770-b2d5-75d6559d1092

scrollTop이나 clientHeight이 0.5 단위로 잡혀서 맨 밑으로 스크롤해도 scrollHeight보다 작음

