### PR TITLE
welcome 페이지 Footer 버튼이 고정되지 않는 이슈 수정

### DIFF
--- a/src/pages/Welcome/Welcome.tsx
+++ b/src/pages/Welcome/Welcome.tsx
@@ -64,7 +64,7 @@ function Welcome() {
           </HowToContainer>
         </WelcomeContents>
       </WelcomeContainer>
-      <Footer style={{ backgroundColor: '#f6f6f6', padding: '8px 32px' }}>
+      <Footer style={{ position: 'fixed', backgroundColor: '#f6f6f6', padding: '8px 32px' }}>
         <FullHeightButtonGroup fullWidth disableElevation variant="contained">
           <Button onClick={handleClick}>{'모임 만들기'}</Button>
         </FullHeightButtonGroup>

--- a/src/templates/MeetingEdit/styled.tsx
+++ b/src/templates/MeetingEdit/styled.tsx
@@ -67,6 +67,7 @@ export const WelcomeContainer = styled('div')({
   overflow: 'scroll',
   display: 'flex',
   flexDirection: 'column',
+  paddingBottom: '64px',
 });
 
 export const PasswordInput = styled('div')({


### PR DESCRIPTION
- welcome 페이지에 PageLayout을 적용하지 않으며 Footer의 sticky가 적용되지 않음

  welcome 페이지의 Footer에 position fixed를 인라인 스타일로 적용