### PR TITLE
InputPasswordModal 에서 focus가 잘 잡히도록 렌더링을 살짝 지연시킴

### DIFF
--- a/src/hooks/MeetingView/useMeetingViewHeader.ts
+++ b/src/hooks/MeetingView/useMeetingViewHeader.ts
@@ -28,7 +28,10 @@ export const useMeetingViewHeader = () => {
 
   // Create a promise that resolves when the user closes the password input modal
   const openInputPasswordModal = () => {
-    setShowPasswordModal(true);
+    // delay modal rendering to give the modal input focus
+    setTimeout(() => {
+      setShowPasswordModal(true);
+    }, 100);
 
     const inputPasswordFinishPromise = new Promise((resolve, reject) => {
       addEventListener(


### PR DESCRIPTION
- InputPasswordModal을 띄울때 자동으로 focus가 가야하는데, 잡히지 않는 이슈
- setTimeout으로 delay를 줄 경우 문제가 해결되어 workaround 처리