### PR TITLE
Safari에서 100vh 설정으로 인해서 하단버튼이 가려지는 이슈 해결

### DIFF
--- a/src/components/pageLayout.tsx
+++ b/src/components/pageLayout.tsx
@@ -16,6 +16,12 @@ export const Page = styled('div')`
   padding-bottom: 64px;
 `;
 
+const LayoutWrapper = styled('div')`
+  height: 100dvh;
+  overflow: hidden;
+  position: relative;
+`;
+
 const ContentsWrapper = styled(Box)`
   padding: 0 32px 0;
   height: 100%;
@@ -42,13 +48,13 @@ export const Footer = styled('footer')({
 export const PageLayout = (props: { useHeader?: boolean }) => {
   const { useHeader = true } = props;
   return (
-    <div style={{ height: 'calc(var(--vh, 1vh)*100 )', overflow: 'hidden', position: 'relative' }}>
+    <LayoutWrapper>
       {useHeader && <Header></Header>}
       <ContentsWrapper>
         <ContentsBox {...props}>
           <Outlet />
         </ContentsBox>
       </ContentsWrapper>
-    </div>
+    </LayoutWrapper>
   );
 };


### PR DESCRIPTION
#288 이슈에서 하단버튼 이슈

- dvh 속성 사용해서 하단 주소창 제외하고 vh로 잡히도록 조정

## Reference

- https://web.dev/blog/viewport-units