### PR TITLE
Skeleton 유저네임 목록이 테두리를 벗어나는 이슈 수정

### DIFF
--- a/src/components/MeetingContentsSkeleton.tsx
+++ b/src/components/MeetingContentsSkeleton.tsx
@@ -34,9 +34,9 @@ const MeetingContentsSkeleton = () => {
             borderRadius: '4px',
           }}
         >
-          <div style={{ display: 'flex', gap: '8px' }}>
+          <div style={{ display: 'flex', gap: '8px', width: '100%' }}>
             {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} width="100px" variant="rounded" />
+              <Skeleton key={i} width="100%" variant="rounded" />
             ))}
           </div>
         </div>


### PR DESCRIPTION
closes #291 

- 유저네임 목록 상위 div의 너비를 100%, 유저네임 각각의 너비를 33%로 설정

![image](https://github.com/Team-Panopticon/TBD-client/assets/55068119/00edc9fa-b8e9-49e8-bde2-6b68eae03f18)
